### PR TITLE
Fix for #210 "Enhance GitHub Icon Visibility"

### DIFF
--- a/src/components/common/Combobox.tsx
+++ b/src/components/common/Combobox.tsx
@@ -117,7 +117,7 @@ export function Combobox(props: Props) {
                     />
                   ) : item.value.startsWith("github") ? (
                     <img
-                      className="mr-2 inline-block h-4 w-4"
+                      className="mr-2 inline-block h-4 w-4 dark:invert"
                       src="/assets/github.svg"
                       alt="GitHub"
                     />


### PR DESCRIPTION
https://github.com/l3montree-dev/devguard/issues/210

solved now, improved clarity and visibility!

https://github.com/user-attachments/assets/ac9bb997-24cb-4da8-b36c-8b9840ebf0af


