### PR TITLE
128 add warning alert before deleting a personal access token

### DIFF
--- a/src/components/common/ConfirmTokenDeletion.tsx
+++ b/src/components/common/ConfirmTokenDeletion.tsx
@@ -1,0 +1,47 @@
+import React, { FunctionComponent, PropsWithChildren } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "../ui/alert-dialog";
+// For reference http://localhost:3000/l3montree/settings
+
+interface Props {
+  Button: React.ReactNode;
+}
+const ConfirmTokenDeletion: FunctionComponent<PropsWithChildren<Props>> = ({
+  Button,
+  children,
+}) => {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{children}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            Are you sure you want to delete your token?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            The token will be permanently deleted. This action cannot be undone,
+            and you will lose access to any services associated with it. Are you
+            sure you want to proceed?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction className="" asChild>
+            {Button}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default ConfirmTokenDeletion;

--- a/src/components/common/ConfirmTokenDeletion.tsx
+++ b/src/components/common/ConfirmTokenDeletion.tsx
@@ -35,9 +35,7 @@ const ConfirmTokenDeletion: FunctionComponent<PropsWithChildren<Props>> = ({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction className="" asChild>
-            {Button}
-          </AlertDialogAction>
+          {Button}
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/components/ui/button.test.tsx
+++ b/src/components/ui/button.test.tsx
@@ -1,0 +1,18 @@
+import { Button, buttonVariants } from "./button";
+import { render, screen } from "@testing-library/react";
+
+describe("button variant test", () => {
+  it("should include bg-destructive if passed a destructive button variant", () => {
+    const actual = buttonVariants({ variant: "destructive" });
+    expect(actual).toContain("bg-destructive");
+  });
+});
+
+describe("button variant component test", () => {
+  it("should include the bg-destructive as className if passed a destructive button variant", async () => {
+    render(<Button variant={"destructive"}>Destructive Button</Button>);
+    expect((await screen.findByText("Destructive Button")).className).toContain(
+      "bg-destructive",
+    );
+  });
+});

--- a/src/pages/user-settings.tsx
+++ b/src/pages/user-settings.tsx
@@ -306,7 +306,7 @@ const Settings: FunctionComponent<{
                     <ConfirmTokenDeletion
                       Button={
                         <Button
-                          className="destructive"
+                          variant="destructive"
                           onClick={() => onDeletePat(pat)}
                         >
                           Yes

--- a/src/pages/user-settings.tsx
+++ b/src/pages/user-settings.tsx
@@ -306,7 +306,7 @@ const Settings: FunctionComponent<{
                     <ConfirmTokenDeletion
                       Button={
                         <Button
-                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90" //variant destructive doesnt apply here for some reason
+                          className="destructive"
                           onClick={() => onDeletePat(pat)}
                         >
                           Yes

--- a/src/pages/user-settings.tsx
+++ b/src/pages/user-settings.tsx
@@ -55,6 +55,7 @@ import {
 } from "../services/devGuardApi";
 import { handleFlowError, ory } from "../services/ory";
 import { PersonalAccessTokenDTO } from "../types/api/api";
+import ConfirmTokenDeletion from "@/components/common/ConfirmTokenDeletion";
 
 interface Props {
   flow?: SettingsFlow;
@@ -302,12 +303,18 @@ const Settings: FunctionComponent<{
                     </>
                   }
                   Button={
-                    <Button
-                      variant="secondary"
-                      onClick={() => onDeletePat(pat)}
+                    <ConfirmTokenDeletion
+                      Button={
+                        <Button
+                          variant="destructive"
+                          onClick={() => onDeletePat(pat)}
+                        >
+                          Yes
+                        </Button>
+                      }
                     >
-                      Delete
-                    </Button>
+                      <Button>Delete</Button>
+                    </ConfirmTokenDeletion>
                   }
                 />
               ),

--- a/src/pages/user-settings.tsx
+++ b/src/pages/user-settings.tsx
@@ -306,7 +306,7 @@ const Settings: FunctionComponent<{
                     <ConfirmTokenDeletion
                       Button={
                         <Button
-                          variant="destructive"
+                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90" //variant destructive doesnt apply here for some reason
                           onClick={() => onDeletePat(pat)}
                         >
                           Yes


### PR DESCRIPTION
so, everything should work now, only strange part is that the variant destructive doesn't apply, I manually copied the tailwind code defined in destructive and applied them and now it works, I honestly don't know why it behaves that way