### PR TITLE
Added pre-select to 'Scan' option and capitalize Scan/Manage elements within user-settings page

### DIFF
--- a/src/pages/user-settings.tsx
+++ b/src/pages/user-settings.tsx
@@ -95,7 +95,13 @@ const Settings: FunctionComponent<{
     description: string;
     scan: boolean;
     manage: boolean;
-  }>();
+  }>({
+    defaultValues: {
+      description: "",
+      scan: true, // so scan is checked by default
+      manage: false,
+    }
+  });
 
   const { personalAccessTokens, onDeletePat, onCreatePat, pat } =
     usePersonalAccessToken(pats);
@@ -296,7 +302,7 @@ const Settings: FunctionComponent<{
 
                 <div className="mt-4 flex items-center justify-between gap-2">
                   <Label htmlFor="scan" className="flex-1">
-                    scan
+                    Scan
                     <span className="block text-sm text-gray-500">
                       Use this token to scan your repositories.
                     </span>
@@ -309,7 +315,7 @@ const Settings: FunctionComponent<{
 
                 <div className="mt-4 flex items-center justify-between gap-2">
                   <Label htmlFor="manage" className="flex-1">
-                    manage
+                    Manage
                     <span className="block text-sm text-gray-500">
                       Use this token to manage your repositories.
                     </span>


### PR DESCRIPTION
## Files Changed
`devguard-web/src/pages/user-settings.tsx`

## Fixes 
- Added a `defaultValues` object with option fields and set `scan: true`
- `watch("scan")` will now return `true` on first render, so the
Switch is checked
- `handleSubmit` receives `{ description: "...", scan: true, manage: false }` unless the user turns it off

## Why
Fixes l3montree-dev/devguard#603

## Visual
![image](https://github.com/user-attachments/assets/9b87ae21-5872-4da1-b029-1312985458b0)

