### PR TITLE
Added fingerprint icon to 'Sign In With Passkey' button in login page

### DIFF
--- a/src/components/kratos/NodeInputButton.tsx
+++ b/src/components/kratos/NodeInputButton.tsx
@@ -54,7 +54,12 @@ export function NodeInputButton<T>({
         value={attributes.value || ""}
         disabled={attributes.disabled || disabled}
       >
-        <FingerPrintIcon className="mr-2 h-4 w-4 shrink-0" aria-hidden="true"/>
+        {attributes.name === "passkey_login_trigger" && (
+          <FingerPrintIcon
+            className="mr-2 h-4 w-4 shrink-0"
+            aria-hidden="true"
+          />
+        )}
         {getNodeLabel(node)}
       </Button>
     </div>

--- a/src/components/kratos/NodeInputButton.tsx
+++ b/src/components/kratos/NodeInputButton.tsx
@@ -16,6 +16,7 @@
 import { getNodeLabel } from "@ory/integrations/ui";
 
 import { callWebauthnFunction, NodeInputProps } from "./helpers";
+import { FingerPrintIcon } from "@heroicons/react/24/outline";
 import { Button } from "../ui/button";
 
 export function NodeInputButton<T>({
@@ -53,6 +54,7 @@ export function NodeInputButton<T>({
         value={attributes.value || ""}
         disabled={attributes.disabled || disabled}
       >
+        <FingerPrintIcon className="mr-2 h-4 w-4 shrink-0" aria-hidden="true"/>
         {getNodeLabel(node)}
       </Button>
     </div>


### PR DESCRIPTION

## Fixes
Added a fingerprint icon to the “Sign In with Passkey” submit button rendered by the Kratos component `NodeInputButton`

## Why
Fixes https://github.com/l3montree-dev/devguard/issues/577

## Visual

![image](https://github.com/user-attachments/assets/12a1dab8-d75b-41d9-8fa7-43848069be47)
