### PR TITLE
fix: correct typo 'exis' to 'exist' in vulnerability message

### DIFF
--- a/src/utils/view.ts
+++ b/src/utils/view.ts
@@ -54,7 +54,7 @@ export const vexOptionMessages: Record<string, string> = {
     "The vulnerable code exists but is never executed.",
   vulnerable_code_cannot_be_controlled_by_adversary:
     "The attacker cannot control the vulnerable code.",
-  inline_mitigations_already_exis:
+  inline_mitigations_already_exist:
     "Built-in defenses prevent known exploitation paths.",
 };
 


### PR DESCRIPTION
This pull request fixes a small typo in the VEX option messages.

Changed:
- "inline_mitigations_already_exis" ➜ "inline_mitigations_already_exist"

This improves message clarity and grammar.
