### PR TITLE
1011 turn copycode into whitemode

### DIFF
--- a/src/components/common/Highlighter.tsx
+++ b/src/components/common/Highlighter.tsx
@@ -26,16 +26,10 @@ SyntaxHighlighter.registerLanguage("yaml", yaml);
 SyntaxHighlighter.registerLanguage("shell", shell);
 SyntaxHighlighter.registerLanguage("rego", basic);
 
-const resolveStyle = (styleImport: any) =>
-  styleImport?.default ? styleImport.default : styleImport;
-
-const githubBase = resolveStyle(github);
-const anOldHopeBase = resolveStyle(anOldHope);
-
 const githubLightTheme = {
-  ...githubBase,
+  ...github,
   hljs: {
-    ...(githubBase.hljs || {}),
+    ...(github.hljs || {}),
     background: "transparent",
   },
 };
@@ -65,11 +59,11 @@ const Highlighter: FunctionComponent<{
     return current === "dark";
   }, [resolvedTheme, theme]);
 
-  const textColor = isDark ? "#E2E8F0" : (githubBase.hljs?.color ?? "#24292E");
+  const textColor = isDark ? "#E2E8F0" : (github.hljs?.color ?? "#24292E");
   const lineNumberColor = isDark
     ? "rgba(255, 255, 255, 0.35)"
     : "rgba(71, 85, 105, 0.75)";
-  const syntaxTheme = isDark ? anOldHopeBase : githubLightTheme;
+  const syntaxTheme = isDark ? anOldHope : githubLightTheme;
 
   return (
     <div className="w-full bg-white dark:bg-black">


### PR DESCRIPTION
<img width="745" height="846" alt="image" src="https://github.com/user-attachments/assets/960bb0fe-17d2-41e7-afe5-ec2cb6e33ae5" />
<img width="764" height="629" alt="image" src="https://github.com/user-attachments/assets/40f399ab-3fb4-440e-99fa-f09a70351df6" />
<img width="754" height="598" alt="image" src="https://github.com/user-attachments/assets/cfe73fc9-148e-4949-8257-a94d1501eebb" />


I probably still have to customize the colors the white mode uses the github theme now