### PR TITLE
feat: add 4K character limit to justification input fields

### DIFF
--- a/src/components/AcceptRiskDialog.tsx
+++ b/src/components/AcceptRiskDialog.tsx
@@ -83,13 +83,19 @@ const AcceptRiskDialog: FunctionComponent<AcceptRiskDialogProps> = ({
               placeholder="Add your comment here..."
               value={justification}
               setValue={(value) => setJustification(value ?? "")}
+              maxLength={4000}
             />
           </div>
           <DialogFooter>
             <Button variant="secondary" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <AsyncButton onClick={handleSubmit}>Accept Risk</AsyncButton>
+            <AsyncButton
+              onClick={handleSubmit}
+              disabled={justification.length > 4000}
+            >
+              Accept Risk
+            </AsyncButton>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/src/components/CommentDialog.tsx
+++ b/src/components/CommentDialog.tsx
@@ -62,13 +62,19 @@ const CommentDialog: FunctionComponent<CommentDialogProps> = ({
               placeholder="Add your comment here..."
               value={justification}
               setValue={(value) => setJustification(value ?? "")}
+              maxLength={4000}
             />
           </div>
           <DialogFooter>
             <Button variant="secondary" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <AsyncButton onClick={handleSubmit}>Add Comment</AsyncButton>
+            <AsyncButton
+              onClick={handleSubmit}
+              disabled={justification.length > 4000}
+            >
+              Add Comment
+            </AsyncButton>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/src/components/FalsePositiveDialog.tsx
+++ b/src/components/FalsePositiveDialog.tsx
@@ -205,6 +205,7 @@ const FalsePositiveDialog: FunctionComponent<FalsePositiveDialogProps> = ({
               placeholder="Add your comment here..."
               value={justification}
               setValue={(value) => setJustification(value ?? "")}
+              maxLength={4000}
             />
           </div>
           <DialogFooter>
@@ -217,6 +218,7 @@ const FalsePositiveDialog: FunctionComponent<FalsePositiveDialogProps> = ({
                   onClick={handleSubmit}
                   variant={"default"}
                   className="mr-0 rounded-r-none pr-0 capitalize"
+                  disabled={justification.length > 4000}
                 >
                   {removeUnderscores(selectedOption)}
                 </AsyncButton>

--- a/src/components/MitigateDialog.tsx
+++ b/src/components/MitigateDialog.tsx
@@ -73,13 +73,14 @@ const MitigateDialog: FunctionComponent<MitigateDialogProps> = ({
               placeholder="Add your justification for mitigating this vulnerability..."
               value={justification}
               setValue={(value) => setJustification(value ?? "")}
+              maxLength={4000}
             />
           </div>
           <DialogFooter>
             <Button variant="secondary" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <AsyncButton variant={"secondary"} onClick={handleSubmit}>
+            <AsyncButton variant={"secondary"} onClick={handleSubmit} disabled={justification.length > 4000}>
               <div className="flex flex-row items-center">
                 {integrationType === "gitlab" && (
                   <>

--- a/src/components/common/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor.tsx
@@ -28,12 +28,14 @@ interface Props extends Partial<MDXEditorProps> {
   value: string;
   setValue: (value?: string) => void;
   placeholder?: string;
+  maxLength?: number;
 }
 
 const MarkdownEditor: FunctionComponent<Props> = ({
   value,
   setValue,
   placeholder,
+  maxLength,
   ...rest
 }) => {
   const markdownRef = useRef<MDXEditorMethods>(null);
@@ -41,51 +43,68 @@ const MarkdownEditor: FunctionComponent<Props> = ({
   useEffect(() => {
     markdownRef.current?.setMarkdown(value);
   }, [value]);
-  return (
-    <MDXEditor
-      ref={markdownRef}
-      className={classNames(
-        "ring-primary focus:ring-2 focus-within:ring-2 rounded border",
-        styles.mdxeditor,
-        rest.className || "",
-      )}
-      onChange={(value) => setValue(value)}
-      placeholder={placeholder}
-      markdown={value}
-      contentEditableClassName="mdx-editor-content"
-      plugins={[
-        //    toolbarPlugin({ toolbarContents: () => <KitchenSinkToolbar /> }),
-        toolbarPlugin({
-          toolbarContents: () => (
-            <>
-              <BoldItalicUnderlineToggles />
-              <CodeToggle />
-              <ListsToggle />
-            </>
-          ),
-        }),
-        listsPlugin(),
-        quotePlugin(),
-        headingsPlugin(),
-        linkPlugin(),
-        imagePlugin(),
-        tablePlugin(),
-        thematicBreakPlugin(),
-        frontmatterPlugin(),
-        codeBlockPlugin({ defaultCodeBlockLanguage: "go" }),
-        codeMirrorPlugin({
-          codeBlockLanguages: {
-            js: "JavaScript",
-            css: "CSS",
-            txt: "text",
-            tsx: "TypeScript",
-            go: "Go",
-          },
-        }),
 
-        markdownShortcutPlugin(),
-      ]}
-    />
+  const charCount = value.length;
+  const isOverLimit = maxLength !== undefined && charCount > maxLength;
+
+  return (
+    <div>
+      <MDXEditor
+        ref={markdownRef}
+        className={classNames(
+          "ring-primary focus:ring-2 focus-within:ring-2 rounded border",
+          isOverLimit ? "border-destructive" : "",
+          styles.mdxeditor,
+          rest.className || "",
+        )}
+        onChange={(value) => setValue(value)}
+        placeholder={placeholder}
+        markdown={value}
+        contentEditableClassName="mdx-editor-content"
+        plugins={[
+          //    toolbarPlugin({ toolbarContents: () => <KitchenSinkToolbar /> }),
+          toolbarPlugin({
+            toolbarContents: () => (
+              <>
+                <BoldItalicUnderlineToggles />
+                <CodeToggle />
+                <ListsToggle />
+              </>
+            ),
+          }),
+          listsPlugin(),
+          quotePlugin(),
+          headingsPlugin(),
+          linkPlugin(),
+          imagePlugin(),
+          tablePlugin(),
+          thematicBreakPlugin(),
+          frontmatterPlugin(),
+          codeBlockPlugin({ defaultCodeBlockLanguage: "go" }),
+          codeMirrorPlugin({
+            codeBlockLanguages: {
+              js: "JavaScript",
+              css: "CSS",
+              txt: "text",
+              tsx: "TypeScript",
+              go: "Go",
+            },
+          }),
+
+          markdownShortcutPlugin(),
+        ]}
+      />
+      {maxLength !== undefined && (
+        <p
+          className={classNames(
+            "mt-1 text-right text-xs",
+            isOverLimit ? "text-destructive" : "text-muted-foreground",
+          )}
+        >
+          {charCount} / {maxLength}
+        </p>
+      )}
+    </div>
   );
 };
 


### PR DESCRIPTION
Add maxLength prop to MarkdownEditor with character counter display. Enforce 4K limit in CommentDialog, AcceptRiskDialog, MitigateDialog, and FalsePositiveDialog — submit button disabled when over limit.

Closes #1850