### PR TITLE
Fixed VexRules not being displayed correctly

### DIFF
--- a/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
+++ b/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
@@ -34,7 +34,6 @@ import type {
   AssetDTO,
   DependencyVulnHints,
   DetailedDependencyVulnDTO,
-  Paged,
   VexRule,
   VulnEventDTO,
 } from "@/types/api/api";

--- a/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
+++ b/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
@@ -344,7 +344,6 @@ const Index: FunctionComponent = () => {
       : null,
     fetcher,
   );
-  console.log(vexRulesData)
 
   // Handler to create false-positive rules from the dependency graph context menu
   const createFalsePositive = useCreateVexRule({

--- a/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
+++ b/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
@@ -338,12 +338,13 @@ const Index: FunctionComponent = () => {
   } = useSWR<DetailedDependencyVulnDTO>(uri, fetcher);
 
   // Fetch VEX rules for the current vulnerability to show FP edges in the graph
-  const { data: vexRulesData, mutate: mutateVexRules } = useSWR<Paged<VexRule>>(
+  const { data: vexRulesData, mutate: mutateVexRules } = useSWR<VexRule[]>(
     vuln
       ? `/organizations/${activeOrg.slug}/projects/${project?.slug}/assets/${asset?.slug}/refs/${assetVersion?.slug}/vex-rules/?dependencyVulnId=${encodeURIComponent(vuln.id)}`
       : null,
     fetcher,
   );
+  console.log(vexRulesData)
 
   // Handler to create false-positive rules from the dependency graph context menu
   const createFalsePositive = useCreateVexRule({
@@ -756,7 +757,7 @@ const Index: FunctionComponent = () => {
                                 ...vuln.vulnerabilityPath,
                               ]}
                               onVexSelect={createFalsePositive}
-                              vexRules={vexRulesData?.data}
+                              vexRules={vexRulesData}
                             />
                           )}
                         </div>
@@ -804,13 +805,13 @@ const Index: FunctionComponent = () => {
                       )}
                     </div>
                     {/* VEX Rules applied to this vulnerability */}
-                    {vexRulesData && vexRulesData.data.length > 0 && (
+                    {vexRulesData && vexRulesData.length > 0 && (
                       <div className="mt-6">
                         <span className="font-semibold block mb-2">
-                          VEX Rules ({vexRulesData.data.length})
+                          VEX Rules ({vexRulesData.length})
                         </span>
                         <div className="flex flex-col gap-2">
-                          {vexRulesData.data.map((rule) => (
+                          {vexRulesData.map((rule) => (
                             <button
                               key={rule.id}
                               onClick={() => {


### PR DESCRIPTION
This is a fix related to Issue:https://github.com/l3montree-dev/devguard/issues/1870

The frontend data typing mismatched the data returned by the API. Therefore it did not display the VexRules correctly. 