### PR TITLE
Fixed search behavior: Now returning to page 1 of pagination on search

### DIFF
--- a/src/hooks/useDebouncedQuerySearch.ts
+++ b/src/hooks/useDebouncedQuerySearch.ts
@@ -9,7 +9,7 @@ export default function useDebouncedQuerySearch() {
       debounce((value: string) => {
         updateQueryParams({
           search: value || undefined,
-          page:1
+          page: 1,
         });
       }, 500),
     [updateQueryParams],

--- a/src/hooks/useDebouncedQuerySearch.ts
+++ b/src/hooks/useDebouncedQuerySearch.ts
@@ -9,6 +9,7 @@ export default function useDebouncedQuerySearch() {
       debounce((value: string) => {
         updateQueryParams({
           search: value || undefined,
+          page:1
         });
       }, 500),
     [updateQueryParams],


### PR DESCRIPTION
Fixes Issue: https://github.com/l3montree-dev/devguard/issues/1865

The added change intends to return the user to page 1 of the paginated results. I believe that should be the intended workflow instead of staying on the same page as before the search (likely staying on a page that has no results).

All components/pages that use the `useDebouncedQuerySearch()` hook share this behavior, so the change was implemented directly into the hook.

