### PR TITLE
Added tab whitespacing, save through hotkey and toast to config codeeditor

### DIFF
--- a/src/components/common/CodeEditor.tsx
+++ b/src/components/common/CodeEditor.tsx
@@ -13,6 +13,8 @@ import { useTheme } from "next-themes";
 import { useEffect, useRef } from "react";
 import { StreamLanguage } from "@codemirror/language";
 import { toml } from "@codemirror/legacy-modes/mode/toml";
+import { keymap } from "@codemirror/view";
+import { indentWithTab } from "@codemirror/commands";
 
 function tomlParseLinter() {
   return (view: EditorView): Diagnostic[] => {
@@ -52,6 +54,7 @@ interface Props {
   language?: Language;
   onChange: (value: string) => void;
   onValidation?: (isValid: boolean) => void;
+  onSave: () => void;
   readOnly?: boolean;
 }
 
@@ -72,6 +75,7 @@ const CodeEditor = ({
   language = "json",
   onChange,
   onValidation,
+  onSave,
   readOnly = false,
 }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -80,11 +84,26 @@ const CodeEditor = ({
   onChangeRef.current = onChange;
   const onValidationRef = useRef(onValidation);
   onValidationRef.current = onValidation;
+  const onSaveRef = useRef(onSave);
+  onSaveRef.current = onSave;
   const valueRef = useRef(value);
   valueRef.current = value;
 
   const { resolvedTheme } = useTheme();
   const currentTheme = resolvedTheme === "dark" ? vscodeDark : vscodeLight;
+
+  const tabExtension = keymap.of([indentWithTab]);
+
+  const saveKeymap = keymap.of([
+    {
+      key: "Mod-s",
+      preventDefault: true,
+      run: () => {
+        onSaveRef.current();
+        return true;
+      },
+    },
+  ]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -118,6 +137,8 @@ const CodeEditor = ({
             "&": { height: "100%", fontSize: "13px" },
             ".cm-scroller": { overflow: "auto", fontFamily: "monospace" },
           }),
+          tabExtension,
+          saveKeymap,
         ],
       }),
       parent: containerRef.current,

--- a/src/components/common/CodeEditor.tsx
+++ b/src/components/common/CodeEditor.tsx
@@ -92,21 +92,20 @@ const CodeEditor = ({
   const { resolvedTheme } = useTheme();
   const currentTheme = resolvedTheme === "dark" ? vscodeDark : vscodeLight;
 
-  const tabExtension = keymap.of([indentWithTab]);
-
-  const saveKeymap = keymap.of([
-    {
-      key: "Mod-s",
-      preventDefault: true,
-      run: () => {
-        onSaveRef.current();
-        return true;
-      },
-    },
-  ]);
-
   useEffect(() => {
     if (!containerRef.current) return;
+    const tabExtension = keymap.of([indentWithTab]);
+
+    const saveKeymap = keymap.of([
+      {
+        key: "Mod-s",
+        preventDefault: true,
+        run: () => {
+          onSaveRef.current();
+          return true;
+        },
+      },
+    ]);
 
     const langLinter = languageLinters[language];
 

--- a/src/components/common/ConfigFileEditor.tsx
+++ b/src/components/common/ConfigFileEditor.tsx
@@ -122,7 +122,7 @@ const ConfigFileEditor = ({
           onChange={setEditorValue}
           onValidation={handleEditorValidation}
           onSave={() => {
-            if (!!codeError || editorValue === configFile) return;
+            if (!!codeError || editorValue === configFile || configFile === undefined) return;
             handleConfigFileChange(editorValue);
           }}
           language={selectedLanguage}

--- a/src/components/common/ConfigFileEditor.tsx
+++ b/src/components/common/ConfigFileEditor.tsx
@@ -9,6 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { browserApiClient } from "@/services/devGuardApi";
 import { Pencil } from "lucide-react";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import useSWR from "swr";
 
 const defaultConfigFiles = [
@@ -71,6 +72,7 @@ const ConfigFileEditor = ({
     if (!configFileUrl) {
       return;
     }
+
     const resp = await browserApiClient(configFileUrl, {
       method: "PUT",
       headers: { "Content-Type": "text/plain" },
@@ -81,6 +83,7 @@ const ConfigFileEditor = ({
       setCodeError("Failed to save the new Configuration");
       return;
     }
+    toast.success("Config saved successfully");
     setEditorValue(newConfig);
     setCodeError(null);
     mutate();
@@ -118,6 +121,10 @@ const ConfigFileEditor = ({
           value={editorValue}
           onChange={setEditorValue}
           onValidation={handleEditorValidation}
+          onSave={() => {
+            if (!!codeError || editorValue === configFile) return;
+            handleConfigFileChange(editorValue);
+          }}
           language={selectedLanguage}
         />
         {codeError && <p className="text-sm text-destructive">{codeError}</p>}


### PR DESCRIPTION
Implemented suggestions from Issue: https://github.com/l3montree-dev/devguard/issues/1871

- You can now add whitespaces using the tab button
- You can use hotkeys to save your config (CMD+S on Mac, CTRL + S on Windows/Linux)
- You'll get a toast message after your config was saved successfully