### PR TITLE
fix: filter search requires more than 2 characters

### DIFF
--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -126,6 +126,7 @@ const Filter: FunctionComponent<Props> = ({
   };
 
   const handleSearchForText = () => {
+    if (inputQuery.length < 3) return;
     search?.onChange(inputQuery);
     setActiveSearchQuery(inputQuery);
     setInputQuery("");
@@ -193,7 +194,9 @@ const Filter: FunctionComponent<Props> = ({
 
     let itemCount = 0;
     if (step === "label") {
-      itemCount = filteredOptions.length + (inputQuery && search ? 1 : 0);
+      itemCount =
+        filteredOptions.length +
+        (inputQuery && search && inputQuery.length >= 3 ? 1 : 0);
     } else if (step === "operator") {
       itemCount = operators.length;
     } else if (step === "value" && showFilterValues) {
@@ -291,15 +294,21 @@ const Filter: FunctionComponent<Props> = ({
                     ))}
                   </>
                 )}
-                {inputQuery && search && (
-                  <button
-                    onClick={handleSearchForText}
-                    className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent ${focusedIndex === filteredOptions.length ? "bg-accent" : ""}`}
-                  >
-                    <SearchIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                    Search for &ldquo;{inputQuery}&rdquo;
-                  </button>
-                )}
+                {inputQuery &&
+                  search &&
+                  (inputQuery.length < 3 ? (
+                    <p className="px-3 py-2 text-xs text-muted-foreground">
+                      Please enter at least 3 characters to search.
+                    </p>
+                  ) : (
+                    <button
+                      onClick={handleSearchForText}
+                      className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent ${focusedIndex === filteredOptions.length ? "bg-accent" : ""}`}
+                    >
+                      <SearchIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      Search for &ldquo;{inputQuery}&rdquo;
+                    </button>
+                  ))}
               </div>
             )}
 

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -25,6 +25,8 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { ChevronLeftIcon, FilterIcon, SearchIcon, XIcon } from "lucide-react";
 
+const MIN_SEARCH_LENGTH = 3;
+
 interface FilterOption {
   label: string;
   value: string;
@@ -126,7 +128,7 @@ const Filter: FunctionComponent<Props> = ({
   };
 
   const handleSearchForText = () => {
-    if (inputQuery.length < 3) return;
+    if (inputQuery.length < MIN_SEARCH_LENGTH) return;
     search?.onChange(inputQuery);
     setActiveSearchQuery(inputQuery);
     setInputQuery("");
@@ -196,7 +198,9 @@ const Filter: FunctionComponent<Props> = ({
     if (step === "label") {
       itemCount =
         filteredOptions.length +
-        (inputQuery && search && inputQuery.length >= 3 ? 1 : 0);
+        (inputQuery && search && inputQuery.length >= MIN_SEARCH_LENGTH
+          ? 1
+          : 0);
     } else if (step === "operator") {
       itemCount = operators.length;
     } else if (step === "value" && showFilterValues) {
@@ -296,7 +300,7 @@ const Filter: FunctionComponent<Props> = ({
                 )}
                 {inputQuery &&
                   search &&
-                  (inputQuery.length < 3 ? (
+                  (inputQuery.length < MIN_SEARCH_LENGTH ? (
                     <p className="px-3 py-2 text-xs text-muted-foreground">
                       Please enter at least 3 characters to search.
                     </p>


### PR DESCRIPTION
This pull request improves the search experience in the `Filter` component by enforcing a minimum query length before allowing searches. It prevents accidental or unnecessary searches with very short input and provides clear feedback to users. The most important changes are:

**Search behavior improvements:**

* The search action in `handleSearchForText` is now only triggered if the input query has at least 3 characters, preventing searches on very short queries.
* The option to "Search for" the input query is only shown when the query is at least 3 characters long, ensuring consistency in the UI and logic.

**User feedback enhancements:**

* When the input query is present but shorter than 3 characters, a message is displayed to inform the user that at least 3 characters are required to search, improving user guidance and experience.
* 

<img width="643" height="226" alt="Bildschirmfoto 2026-05-08 um 10 09 58" src="https://github.com/user-attachments/assets/1842cce3-1eb9-4e87-87e7-41207ece7bbf" />

Issue: https://github.com/l3montree-dev/devguard/issues/1916