### PR TITLE
fix: added a custom error message

### DIFF
--- a/src/components/OrgRegister.tsx
+++ b/src/components/OrgRegister.tsx
@@ -45,9 +45,9 @@ export default function OrgRegisterForm(props: Props) {
     });
 
     if (resp.status !== 200) {
-      const error = await resp.json();
-      toast.error("Error creating organization", {
-        description: error,
+      toast.error("Could not create organization", {
+        description:
+          "Organization creation is currently disabled or an error occurred. Please contact your administrator.",
       });
       return;
     }


### PR DESCRIPTION
This pull request updates the error handling in the `OrgRegisterForm` component to provide a clearer and more user-friendly message when organization creation fails.

Error handling improvements:

* Updated the error toast message in `OrgRegisterForm` to indicate that organization creation is currently disabled or an error occurred, and to instruct users to contact their administrator. The error description is now a static message rather than the raw server response.

https://github.com/l3montree-dev/devguard/issues/1957