### PR TITLE
fix: fixed the column off

### DIFF
--- a/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependencies/page.tsx
+++ b/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependencies/page.tsx
@@ -248,13 +248,17 @@ const columnsDef: ColumnDef<
     cell: (row) => (
       <span className="flex flex-row items-center gap-2">
         <Tooltip>
-          <TooltipTrigger className="flex flex-row items-center gap-2">
-            <EcosystemImage packageName={row.getValue()} size={16} />
-            <span className="font-medium truncate">
-              {beautifyPurl(row.getValue())}
+          <TooltipTrigger className="flex flex-row items-center gap-2 min-w-0 w-full text-left">
+            <span className="shrink-0 mt-0.5">
+              <EcosystemImage packageName={row.getValue()} size={16} />
             </span>
-            <span className="text-xs text-muted-foreground">
-              {extractVersion(row.getValue())}
+            <span className="flex flex-col min-w-0 items-start w-full">
+              <span className="font-medium truncate w-full">
+                {beautifyPurl(row.getValue())}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {extractVersion(row.getValue())}
+              </span>
             </span>
           </TooltipTrigger>
           <TooltipContent>


### PR DESCRIPTION
This pull request improves the layout and responsiveness of the dependency table in the asset dependencies page. The main change is to enhance how package information is displayed, ensuring better alignment and truncation for long package names.

https://github.com/l3montree-dev/devguard/issues/1954

<img width="1360" height="714" alt="Bildschirmfoto 2026-05-15 um 11 11 44" src="https://github.com/user-attachments/assets/4df0cfc3-b1c2-4dc1-87eb-d57637a19a84" />
