### PR TITLE
fix: added badge for licenses

### DIFF
--- a/src/components/risk-handling/LicenseRiskRow.tsx
+++ b/src/components/risk-handling/LicenseRiskRow.tsx
@@ -50,7 +50,7 @@ export default function LicenseRiskRow({ risk, index, arrLength }: Props) {
             Unknown
           </Badge>
         ) : (
-          risk.component.license
+          <Badge variant="secondary">{risk.component.license}</Badge>
         )}
       </td>
       <td className="p-4">


### PR DESCRIPTION
https://github.com/l3montree-dev/devguard/issues/1972

I've added Badge with variant secondary because i think this is readable and points the real licenses out

<img width="984" height="169" alt="Bildschirmfoto 2026-05-18 um 11 15 15" src="https://github.com/user-attachments/assets/8f58bd23-f5b9-4050-a9fb-31965543c7e2" />
