### PR TITLE
fix: fixed that hover asset list overlays text color

### DIFF
--- a/src/components/group-list/AssetRow.tsx
+++ b/src/components/group-list/AssetRow.tsx
@@ -17,7 +17,7 @@ const AssetRow: FunctionComponent<Props> = ({ asset, projectSlug }) => {
   return (
     <Link
       href={`/${activeOrg.slug}/projects/${projectSlug}/assets/${asset.slug}/`}
-      className="block no-underline text-inherit"
+      className="nav-link block no-underline text-inherit"
     >
       <div className="flex flex-row items-center gap-3 rounded-md px-3 py-2 transition-colors hover:bg-accent">
         {asset.avatar ? (

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -306,3 +306,9 @@ a {
         @apply opacity-80;
     }
 }
+
+a.nav-link {
+    &:hover {
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
https://github.com/l3montree-dev/devguard/issues/1966

<img width="225" height="232" alt="Bildschirmfoto 2026-05-18 um 11 54 23" src="https://github.com/user-attachments/assets/0a922579-e35a-4a76-aa1f-e30d02401c22" />
<img width="214" height="138" alt="Bildschirmfoto 2026-05-18 um 11 54 41" src="https://github.com/user-attachments/assets/3ae61ff6-4b58-49d5-b79a-7648e1057ef0" />
