### PR TITLE
Fix long package qualifier display

### DIFF
--- a/src/components/risk-handling/RiskHandlingRow.tsx
+++ b/src/components/risk-handling/RiskHandlingRow.tsx
@@ -17,7 +17,9 @@ import type { VulnByPackage, VulnWithCVE } from "@/types/api/api";
 import {
   beautifyPurl,
   classNames,
+  extractPurlQualifiers,
   extractVersion,
+  formatPurlQualifiers,
   stateLabels,
 } from "@/utils/common";
 import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
@@ -159,13 +161,6 @@ const VulnWithCveTableRow = ({
   );
 };
 
-const extractQualifiers = (purl: string) => {
-  const parts = purl.split("?");
-  if (parts.length < 2) return "";
-  const qualifiersPart = parts[1];
-  const qualifiers = qualifiersPart.split("&").join(", ");
-  return qualifiers;
-};
 const RiskHandlingRow: FunctionComponent<Props> = ({
   row,
   index,
@@ -181,6 +176,10 @@ const RiskHandlingRow: FunctionComponent<Props> = ({
   const vulnGroups = useMemo(
     () => groupBy(row.original.vulns, "cveID"),
     [row.original.vulns],
+  );
+  const packageQualifiers = extractPurlQualifiers(row.original.packageName);
+  const displayPackageQualifiers = formatPurlQualifiers(
+    row.original.packageName,
   );
 
   const toggleCve = (cveID: string) => {
@@ -206,7 +205,7 @@ const RiskHandlingRow: FunctionComponent<Props> = ({
         onClick={() => setIsPackageOpen((prev) => !prev)}
       >
         <td className="py-3 px-4">
-          <div className="flex items-center gap-2">
+          <div className="flex min-w-0 items-center gap-2">
             {isPackageOpen ? (
               <ChevronDownIcon className="w-4 h-4 text-muted-foreground flex-shrink-0" />
             ) : (
@@ -220,9 +219,18 @@ const RiskHandlingRow: FunctionComponent<Props> = ({
               {extractVersion(row.original.packageName)}
             </span>
 
-            <span className="text-xs text-muted-foreground">
-              {extractQualifiers(row.original.packageName)}
-            </span>
+            {packageQualifiers && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="max-w-64 truncate whitespace-nowrap text-xs text-muted-foreground">
+                    {displayPackageQualifiers}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-sm break-all">
+                  {packageQualifiers}
+                </TooltipContent>
+              </Tooltip>
+            )}
           </div>
         </td>
         <td className="py-3 px-4 flex">

--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -1,9 +1,42 @@
-import { beautifyPurl } from "./common";
+import {
+  beautifyPurl,
+  extractPurlQualifiers,
+  formatPurlQualifiers,
+} from "./common";
 
 describe("beautifyPurl", () => {
   it("handles package names containing an '@' correct", () => {
     expect(beautifyPurl("pkg:npm/@ory/integrations@1.2.1")).toBe(
       "@ory/integrations",
     );
+  });
+});
+
+describe("extractPurlQualifiers", () => {
+  it("extracts npm mirror qualifiers without the package name or version", () => {
+    expect(
+      extractPurlQualifiers(
+        "pkg:npm/dompurify@3.4.2?download_url=https%3A%2F%2Fregistry.example.com%2Fdompurify-3.4.2.tgz",
+      ),
+    ).toBe(
+      "download_url=https%3A%2F%2Fregistry.example.com%2Fdompurify-3.4.2.tgz",
+    );
+  });
+
+  it("returns an empty string when the purl has no qualifiers", () => {
+    expect(extractPurlQualifiers("pkg:npm/dompurify@3.4.2")).toBe("");
+  });
+});
+
+describe("formatPurlQualifiers", () => {
+  it("keeps long npm mirror qualifiers to a bounded display length", () => {
+    const formatted = formatPurlQualifiers(
+      "pkg:npm/dompurify@3.4.2?download_url=https%3A%2F%2Ftotally-long-internal-download-url.de%2Fartifactory%2Fapi%2Fnpm%2Fnpm%2Fdompurify%2F-%2Fdompurify-3.4.2.tgz",
+      48,
+    );
+
+    expect(formatted.length).toBeLessThanOrEqual(48);
+    expect(formatted).toContain("...");
+    expect(formatted.startsWith("download_url=")).toBe(true);
   });
 });

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -196,6 +196,15 @@ export const extractVersion = (purl: string) => {
   return versionPart;
 };
 
+export const extractPurlQualifiers = (purl: string) => {
+  const [, qualifiersPart] = purl.split("?", 2);
+  if (!qualifiersPart) {
+    return "";
+  }
+
+  return qualifiersPart.split("&").join(", ");
+};
+
 export const isValidPackagePurl = (purl: string): boolean => {
   if (!purl) return false;
   // PURL format: pkg:<type>/<namespace?>/<name>@<version?>?<qualifiers?>#<subpath?>
@@ -420,6 +429,9 @@ export const truncateMiddle = (
 
   return text.slice(0, start) + "..." + text.slice(-end);
 };
+
+export const formatPurlQualifiers = (purl: string, maxLength = 48) =>
+  truncateMiddle(extractPurlQualifiers(purl), maxLength);
 
 // round any number to its 2nd digit using math round
 export function roundToSecondDigit(num?: number): number {


### PR DESCRIPTION
## Summary
- extract PURL qualifiers through a shared utility
- truncate long qualifier text in dependency risk rows so mirrored npm download URLs stay on one line
- keep the full qualifier string available in the title tooltip

Fixes l3montree-dev/devguard#2033

## Tests
- safe-install npm ci
- npm test -- src/utils/common.test.ts --runInBand
- npm test -- --runInBand
- ./node_modules/.bin/tsc --noEmit
- npm run lint (passes with existing hook dependency warnings)
- ./node_modules/.bin/prettier --check src/utils/common.ts src/utils/common.test.ts src/components/risk-handling/RiskHandlingRow.tsx
- npm audit signatures