### PR TITLE
Fix autosetup loading after failed setup

### DIFF
--- a/src/hooks/useAutosetup.test.tsx
+++ b/src/hooks/useAutosetup.test.tsx
@@ -1,0 +1,68 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+
+import { browserApiClient } from "@/services/devGuardApi";
+import { useAutosetup } from "./useAutosetup";
+
+jest.mock("@/services/devGuardApi", () => ({
+  browserApiClient: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: Object.assign(jest.fn(), {
+    error: jest.fn(),
+  }),
+}));
+
+jest.mock("./useActiveAsset", () => ({
+  useActiveAsset: () => ({
+    slug: "asset-a",
+    externalEntityProviderId: undefined,
+  }),
+}));
+
+jest.mock("./useActiveOrg", () => ({
+  useActiveOrg: () => ({
+    slug: "org-a",
+    externalEntityProviderId: undefined,
+  }),
+}));
+
+jest.mock("./useActiveProject", () => ({
+  useActiveProject: () => ({
+    slug: "project-a",
+  }),
+}));
+
+const onCreatePat = jest.fn();
+
+jest.mock("./usePersonalAccessToken", () => ({
+  __esModule: true,
+  default: () => ({
+    personalAccessTokens: [],
+    onCreatePat,
+  }),
+}));
+
+describe("useAutosetup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    onCreatePat.mockResolvedValue({ privKey: "secret" });
+    (browserApiClient as jest.Mock).mockResolvedValue({ ok: false });
+  });
+
+  it("stops loading when autosetup request fails", async () => {
+    const { result } = renderHook(() =>
+      useAutosetup(false, "https://devguard.example", "full"),
+    );
+
+    await act(async () => {
+      await result.current.handleAutosetup(false);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(toast).toHaveBeenCalledWith("Failed to setup GitLab integration");
+  });
+});

--- a/src/hooks/useAutosetup.ts
+++ b/src/hooks/useAutosetup.ts
@@ -80,22 +80,22 @@ export function useAutosetup(
     }),
   });
 
-  const handleAutosetup = waitFor<boolean, void>((pendingAutosetup = false) => {
-    // check if the asset is an external entity
-    if (asset?.externalEntityProviderId && !pendingAutosetup) {
-      // we need to redirect the user to authorize the "autosetup" oauth2 application
-      sessionStorage.setItem("pending-autosetup", "true");
-      window.location.href =
-        window.location.origin +
-        "/api/devguard-tunnel/api/v1/oauth2/gitlab/" +
-        asset.externalEntityProviderId.replace("@", "") +
-        "autosetup?redirectTo=" +
-        encodeURIComponent(window.location.href);
+  const handleAutosetup = waitFor<boolean, void>(
+    async (pendingAutosetup = false) => {
+      // check if the asset is an external entity
+      if (asset?.externalEntityProviderId && !pendingAutosetup) {
+        // we need to redirect the user to authorize the "autosetup" oauth2 application
+        sessionStorage.setItem("pending-autosetup", "true");
+        window.location.href =
+          window.location.origin +
+          "/api/devguard-tunnel/api/v1/oauth2/gitlab/" +
+          asset.externalEntityProviderId.replace("@", "") +
+          "autosetup?redirectTo=" +
+          encodeURIComponent(window.location.href);
 
-      return Promise.resolve();
-    }
+        return Promise.resolve();
+      }
 
-    return new Promise<void>(async (resolve) => {
       // create a new one for autosetup
       const privKey = (
         await onCreatePat({
@@ -167,12 +167,12 @@ export function useAutosetup(
             });
           }
         }
-        resolve();
-      } else {
-        toast("Failed to setup GitLab integration");
+        return;
       }
-    });
-  });
+
+      toast("Failed to setup GitLab integration");
+    },
+  );
 
   const autosetupOnce = useCallback(once(handleAutosetup), []);
 


### PR DESCRIPTION
## Summary
- make `handleAutosetup` settle when the autosetup API returns a failed response
- keep the existing failure toast, but allow `useLoader` to clear `isLoading`
- add a regression test for failed autosetup requests

Fixes l3montree-dev/devguard#2015

## Validation
- `npm test -- src/hooks/useAutosetup.test.tsx --runInBand`
- `npm test -- --runInBand`
- `./node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `./node_modules/.bin/prettier --check src/hooks/useAutosetup.ts src/hooks/useAutosetup.test.tsx`
- `npm audit signatures`

Note: `npm run lint` reports existing hook dependency warnings in the repo, including pre-existing warnings in `useAutosetup.ts`; no lint errors remain.