### PR TITLE
fix: use toml for gitleaks config editor

### DIFF
--- a/src/components/common/ConfigFileEditor.tsx
+++ b/src/components/common/ConfigFileEditor.tsx
@@ -15,7 +15,7 @@ import useSWR from "swr";
 
 const defaultConfigFiles = [
   { value: "trivy", label: "Trivy", language: "yaml" },
-  { value: "gitleaks-config", label: "Gitleaks", language: "json" },
+  { value: "gitleaks-config", label: "Gitleaks", language: "toml" },
   { value: "semgrep-config", label: "Semgrep", language: "toml" },
   { value: "checkov-config", label: "Checkov", language: "yaml" },
 ];


### PR DESCRIPTION
Fixes l3montree-dev/devguard#2064

## Changes
- Switch the Gitleaks config editor from JSON to TOML mode.
- This makes the editor fetch and save `gitleaks-config.toml` and use the existing TOML parser/linter.

## Verification
- `npx prettier --check src/components/common/ConfigFileEditor.tsx`
- `npx eslint src/components/common/ConfigFileEditor.tsx`
- `npx tsc --noEmit`