### PR TITLE
Fix toast theme in dark mode

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import "focus-visible";
 import { ThemeProvider } from "next-themes";
 import localFont from "next/font/local";
 import React, { Suspense } from "react";
-import { Toaster } from "sonner";
+import { Toaster } from "@/components/ui/sonner";
 import { config } from "../config";
 import MobileGate from "@/components/MobileGate";
 import { CSSVariableEditor } from "@/components/themes/CSSVariableEditor";


### PR DESCRIPTION
## Summary

Fixes the issue where toast notifications appeared in light mode while the application was using dark mode.

## Changes

* Replaced the direct Sonner `Toaster` import with the project's existing theme-aware wrapper component.

## Root Cause

The app imported `Toaster` directly from `sonner`, which bypassed the existing theme-aware implementation in `src/components/ui/sonner.tsx`.

## Result

Toast notifications now correctly follow the active application theme in both light and dark modes.
