### PR TITLE
fix: added a rule to the artifact form field

### DIFF
--- a/src/components/common/ArtifactForm.tsx
+++ b/src/components/common/ArtifactForm.tsx
@@ -41,6 +41,7 @@ const ArtifactForm = ({ form, isEditMode = false }: Props) => {
       <FormField
         control={form.control}
         name="artifactName"
+        rules={{ required: "Artifact name is required" }}
         render={({ field }) => (
           <FormItem>
             <FormLabel>Artifact Name</FormLabel>


### PR DESCRIPTION
https://github.com/l3montree-dev/devguard/issues/1979

Added rules={{ required: "Artifact name is required" }} to the artifactName field so that react-hook-form blocks form submission and displays an inline validation error when the artifact name is left empty. This solves the broken ui issue.

<img width="781" height="583" alt="Bildschirmfoto 2026-06-03 um 13 56 26" src="https://github.com/user-attachments/assets/1c2d258f-bf41-40b1-9615-ee2bb4cb6eb7" />
