### PR TITLE
fix: show matching rules for reopened vulnerabilities

### DIFF
--- a/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
+++ b/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
@@ -45,6 +45,7 @@ import type {
   VulnEventDTO,
 } from "@/types/api/api";
 import { RequirementsLevel } from "@/types/api/api";
+import { getVexRulesSectionLabel } from "@/utils/vexRuleHelpers";
 import { getIntegrationNameFromRepositoryIdOrExternalProviderId } from "@/utils/view";
 import {
   InformationCircleIcon,
@@ -919,7 +920,9 @@ const Index: FunctionComponent = () => {
                         </div>
                       )}
                       <span className="font-semibold block mb-2">
-                        Applied Rules ({vexRulesData?.length || 0})
+                        {vuln
+                          ? `${getVexRulesSectionLabel(vexRulesData ?? [], vuln)} (${vexRulesData?.length ?? 0})`
+                          : `Matching Rules (${vexRulesData?.length ?? 0})`}
                       </span>
                       {vexRulesData && vexRulesData.length > 0 && (
                         <div className="flex flex-col gap-2">

--- a/src/utils/vexRuleHelpers.test.ts
+++ b/src/utils/vexRuleHelpers.test.ts
@@ -1,0 +1,81 @@
+import type { DetailedDependencyVulnDTO, VexRule } from "@/types/api/api";
+import {
+  getVexRulesSectionLabel,
+  isVexRuleAppliedToVuln,
+} from "./vexRuleHelpers";
+
+const baseVuln = {
+  state: "open",
+} as DetailedDependencyVulnDTO;
+
+const falsePositiveRule = {
+  id: "rule-1",
+  eventType: "falsePositive",
+} as VexRule;
+
+const acceptedRule = {
+  id: "rule-2",
+  eventType: "accepted",
+} as VexRule;
+
+describe("isVexRuleAppliedToVuln", () => {
+  it("returns true when false positive rule matches vuln state", () => {
+    expect(
+      isVexRuleAppliedToVuln(falsePositiveRule, {
+        ...baseVuln,
+        state: "falsePositive",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when vuln was reopened (state is open)", () => {
+    expect(
+      isVexRuleAppliedToVuln(falsePositiveRule, {
+        ...baseVuln,
+        state: "open",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when accepted rule matches vuln state", () => {
+    expect(
+      isVexRuleAppliedToVuln(acceptedRule, {
+        ...baseVuln,
+        state: "accepted",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("getVexRulesSectionLabel", () => {
+  it('shows "Matching Rules" when rule is not currently applied (reopened vuln)', () => {
+    expect(
+      getVexRulesSectionLabel([falsePositiveRule], {
+        ...baseVuln,
+        state: "open",
+      }),
+    ).toBe("Matching Rules");
+  });
+
+  it('shows "Applied Rules" when false positive rule is applied', () => {
+    expect(
+      getVexRulesSectionLabel([falsePositiveRule], {
+        ...baseVuln,
+        state: "falsePositive",
+      }),
+    ).toBe("Applied Rules");
+  });
+
+  it('shows "Matching Rules" when only some rules are applied', () => {
+    expect(
+      getVexRulesSectionLabel([falsePositiveRule, acceptedRule], {
+        ...baseVuln,
+        state: "falsePositive",
+      }),
+    ).toBe("Matching Rules");
+  });
+
+  it('shows "Matching Rules" when there are no rules', () => {
+    expect(getVexRulesSectionLabel([], baseVuln)).toBe("Matching Rules");
+  });
+});

--- a/src/utils/vexRuleHelpers.ts
+++ b/src/utils/vexRuleHelpers.ts
@@ -1,0 +1,27 @@
+import type { DetailedDependencyVulnDTO, VexRule } from "@/types/api/api";
+
+export function isVexRuleAppliedToVuln(
+  rule: VexRule,
+  vuln: DetailedDependencyVulnDTO,
+): boolean {
+  if (rule.eventType === "falsePositive") {
+    return vuln.state === "falsePositive";
+  }
+  if (rule.eventType === "accepted") {
+    return vuln.state === "accepted";
+  }
+  return false;
+}
+
+export function getVexRulesSectionLabel(
+  rules: VexRule[],
+  vuln: DetailedDependencyVulnDTO,
+): string {
+  if (rules.length === 0) {
+    return "Matching Rules";
+  }
+  const allApplied = rules.every((rule) =>
+    isVexRuleAppliedToVuln(rule, vuln),
+  );
+  return allApplied ? "Applied Rules" : "Matching Rules";
+}


### PR DESCRIPTION
## Summary

Addresses the label correction portion of issue #2114.

Previously, the vulnerability details page always displayed **"Applied Rules"** even when a vulnerability had been reopened and the matching VEX rule was no longer applied.

This change introduces helper functions to determine whether a VEX rule is currently applied to a vulnerability and updates the UI to display the correct label:

* **Applied Rules** when all matching rules are currently applied.
* **Matching Rules** when rules match but are no longer applied (for example, after a vulnerability has been reopened).

## Changes

* Added `src/utils/vexRuleHelpers.ts`
* Added `src/utils/vexRuleHelpers.test.ts`
* Replaced the hardcoded VEX rules label with a dynamic label in the vulnerability details page

## Testing

Added unit tests covering:

* false positive rule applied
* accepted rule applied
* reopened vulnerability (`state=open`)
* mixed rule states
* empty rule lists

## Related Issue

Partially addresses #2114 (label correction).
