### PR TITLE
Fixed confirm password check

### DIFF
--- a/src/components/ory/flowcomponents/PasswordField.tsx
+++ b/src/components/ory/flowcomponents/PasswordField.tsx
@@ -15,17 +15,14 @@ const PASSWORD_FIELD_CLASS =
 export const CONFIRM_PASSWORD_LABEL = "Confirm Password";
 
 export function usePasswordMismatch(): boolean {
-  const { watch } = useFormContext();
+  const { watch, getValues } = useFormContext();
   const password = watch("password");
   const confirmPassword = watch("confirmPassword");
-  if (!window.location.href.includes("registration")) {
+  const hasConfirmField = "confirmPassword" in getValues();
+  if (!hasConfirmField) {
     return false;
   }
-  if (password) {
-    return password !== confirmPassword;
-  } else {
-    return false;
-  }
+  return password !== confirmPassword;
 }
 
 export function PasswordField({

--- a/src/components/ory/flowcomponents/PasswordField.tsx
+++ b/src/components/ory/flowcomponents/PasswordField.tsx
@@ -18,11 +18,14 @@ export function usePasswordMismatch(): boolean {
   const { watch } = useFormContext();
   const password = watch("password");
   const confirmPassword = watch("confirmPassword");
-  return (
-    typeof confirmPassword === "string" &&
-    confirmPassword.length > 0 &&
-    password !== confirmPassword
-  );
+  if (!window.location.href.includes("registration")) {
+    return false;
+  }
+  if (password) {
+    return password !== confirmPassword;
+  } else {
+    return false;
+  }
 }
 
 export function PasswordField({


### PR DESCRIPTION
The confirm password field condition did not evaluate correctly leading to an issue where you could just register without confirming the password. 

Theoretically this causes no harm since this is an extra reassurance for the user and nothing critical for the functionality. Also the user can reveal the password to check the input.

But this is fixed now. 