### PR TITLE
Instance dashboard text overflow fix

### DIFF
--- a/src/components/admin/InstanceDashboard.tsx
+++ b/src/components/admin/InstanceDashboard.tsx
@@ -250,7 +250,7 @@ export default forwardRef<InstanceDashboardHandle>(
                     key={key}
                     className="flex flex-col gap-2 rounded-md border p-3"
                   >
-                    <span className="text-2xl font-semibold tabular-nums">
+                    <span className="text-xl font-semibold tabular-nums">
                       {formatAvg(avgValue[key])}
                     </span>
                     <span


### PR DESCRIPTION
<img width="595" height="197" alt="Bildschirmfoto 2026-07-03 um 21 21 52" src="https://github.com/user-attachments/assets/6f3c443d-f65b-49ff-9803-86bef9467d39" />

Addresses [#2179](https://github.com/l3montree-dev/devguard/issues/2179)

Simply lowered the text size to xl from 2xl which still looks good and avoids overcomplicating the component.

Realistically, even for a large organization, the number should not reach 6 figures, as that would be in the order of magnitude  of all CVEs in existence.
With this text size there is no overflow up to 5 digits plus 2 decimals as shown in the screenshot.

If I am mistaken and it is feasible that the number could reach 6 figures in a huge organization, I will re-work the component accordingly.