### PR TITLE
fix: load CVSS badge preview from artifact-scoped endpoint

### DIFF
--- a/src/components/asset/asset-form/AssetFormVulnsManagement.tsx
+++ b/src/components/asset/asset-form/AssetFormVulnsManagement.tsx
@@ -431,12 +431,10 @@ const EnableTicketRange: FunctionComponent<Props> = ({ form }) => {
 };
 
 const CVSSBadgePreview: FunctionComponent<{
-  orgSlug: string;
-  projectSlug?: string;
-  assetSlug?: string;
+  badgePreviewUrl: string;
   publicBadgeUrl?: string;
   copyable: boolean;
-}> = ({ orgSlug, projectSlug, assetSlug, publicBadgeUrl, copyable }) => {
+}> = ({ badgePreviewUrl, publicBadgeUrl, copyable }) => {
   const handleCopy = async () => {
     if (!publicBadgeUrl) return;
     try {
@@ -456,7 +454,7 @@ const CVSSBadgePreview: FunctionComponent<{
   return (
     <div className="flex flex-row items-center gap-3 rounded-md border bg-background p-2 justify-between">
       <img
-        src={`/api/devguard-tunnel/api/v1/organizations/${orgSlug}/projects/${projectSlug}/assets/${assetSlug}/badges/cvss/`}
+        src={badgePreviewUrl}
         alt="CVSS Badge"
         className="rounded-md shadow-sm"
       />
@@ -639,6 +637,12 @@ export const AssetFormVulnsManagement: FunctionComponent<Props> = ({
 
   const publicBadgeUrl = basePath ? `${basePath}/badges/cvss/` : undefined;
 
+  const assetApiPath = `/api/devguard-tunnel/api/v1/organizations/${orgSlug}/projects/${projectSlug}/assets/${assetSlug}`;
+  const badgePreviewUrl =
+    selectedVersionSlug && selectedArtifact
+      ? `${assetApiPath}/refs/${selectedVersionSlug}/artifacts/${encodeURIComponent(selectedArtifact)}/badges/cvss/`
+      : `${assetApiPath}/badges/cvss/`;
+
   return (
     <>
       <div className="rounded-lg border shadow-sm bg-card p-4">
@@ -697,9 +701,7 @@ export const AssetFormVulnsManagement: FunctionComponent<Props> = ({
                       onSelectArtifact={setSelectedArtifact}
                     />
                     <CVSSBadgePreview
-                      orgSlug={orgSlug}
-                      projectSlug={projectSlug}
-                      assetSlug={assetSlug}
+                      badgePreviewUrl={badgePreviewUrl}
                       publicBadgeUrl={publicBadgeUrl}
                       copyable={field.value}
                     />


### PR DESCRIPTION
## Problem

Follow-up to l3montree-dev/devguard#2223 (fixes the frontend part of l3montree-dev/devguard#2198).

The CVSS badge preview in the "Enable public access to vulnerability data" dialog always loads the asset-scoped badge endpoint, so it ignores the branch/tag and artifact selected right above it. The public badge URL that gets copied is already artifact-scoped, so the preview could show different values than the copied badge.

## Change

The preview `<img>` now uses the authenticated artifact-scoped endpoint added in l3montree-dev/devguard#2223:

```
GET .../assets/:assetSlug/refs/:assetVersionSlug/artifacts/:artifactName/badges/cvss/
```

built from the currently selected ref and artifact. While no ref/artifact is selected yet (initial load), it falls back to the previous asset-scoped URL. Since the URL is derived from the selection state, the image reloads automatically whenever the user changes branch/tag or artifact.

Note: this requires a devguard API version that includes l3montree-dev/devguard#2223.