### PR TITLE
fix: dashboard top vulnerabilities component styling fix

### DIFF
--- a/src/components/admin/InstanceDashboard.tsx
+++ b/src/components/admin/InstanceDashboard.tsx
@@ -21,7 +21,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getSeverityClassNames } from "@/components/common/Severity";
-import { classNames } from "@/utils/common";
+import { classNames, truncateMiddle } from "@/utils/common";
 import {
   ExclamationTriangleIcon,
   ShieldExclamationIcon,
@@ -289,7 +289,7 @@ export default forwardRef<InstanceDashboardHandle>(
                       <div key={p.slug} className="flex items-end gap-3">
                         <div className="min-w-0 flex-1">
                           <span className="truncate text-sm font-medium">
-                            {p.name}
+                            {truncateMiddle(p.name, 55)}
                           </span>
                           <div className="mt-1 h-2 w-full overflow-hidden rounded-xs bg-secondary">
                             <div
@@ -301,14 +301,19 @@ export default forwardRef<InstanceDashboardHandle>(
                           </div>
                         </div>
                         <div className="flex items-center gap-2">
-                          <span className="text-sm font-medium tabular-nums">
+                          <span
+                            className="text-right text-sm font-medium tabular-nums"
+                            style={{
+                              minWidth: `${String(maxProjectTotal).length}ch`,
+                            }}
+                          >
                             {total}
                           </span>
-                          {p.critical > 0 && (
+                          {/* {p.critical > 0 && (
                             <Badge variant="danger" className="text-xs">
                               {p.critical} critical
                             </Badge>
-                          )}
+                          )} */}
                         </div>
                       </div>
                     );


### PR DESCRIPTION
<img width="587" height="241" alt="fixed" src="https://github.com/user-attachments/assets/2dbda3e5-657d-4d17-9454-7a2a5dbda810" />

Addresses [#2180](https://github.com/l3montree-dev/devguard/issues/2180)

Truncated the project name in the middle for better readability, with a maximum length of 55 characters, which is not too long even if the total vulnerability number is 5 digits long and the critical badge is being displayed.

Additionally, the bars had inconsistent lengths depending on the amount of digits in the number of total vulnerabilities on the right.
Changed this so the bars are always at the same length and the numbers on the right always take as much space as the longest one of them.

Opened an issue ([#2284](https://github.com/l3montree-dev/devguard/issues/2284)) to address the critical badge in this component which is not being displayed properly due to wrong data from the backend.

Because the data is wrong inconsistently across test projects, the critical badge could show up with false information, but most likely never displays anywhere.
To prevent it from appearing with wrong info, I commented it out for now until the backend issue is fixed.