### PR TITLE
fix(web): truncate long repository names in header

### DIFF
--- a/src/components/common/AssetTitle.tsx
+++ b/src/components/common/AssetTitle.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import { Badge } from "../ui/badge";
 import ProjectTitle from "./ProjectTitle";
 import { eventBus } from "@/events";
+import { truncateMiddle } from "@/utils/common";
 
 const AssetTitle = () => {
   const activeOrg = useActiveOrg();
@@ -63,7 +64,9 @@ const AssetTitle = () => {
         }
         title={asset?.name}
       >
-        <span className="truncate">{asset?.name}</span>
+        <span className="truncate">
+          {asset?.name ? truncateMiddle(asset.name) : ""}
+        </span>
         <Badge className="!text-header-foreground" variant="outline">
           Repository
         </Badge>


### PR DESCRIPTION
Long repository names in the asset header overflowed because the name was only wrapped in a CSS `truncate` span that could not shrink inside the flex Link. The group/project names already use truncateMiddle, so apply the same to the repository (asset) name for consistent truncation.

<img width="1608" height="685" alt="Screenshot 2026-07-08 at 22 19 59" src="https://github.com/user-attachments/assets/56e70716-502f-4cd4-ba1c-edc1d7acfeea" />

Fixes #2285 : https://github.com/l3montree-dev/devguard/issues/2285