### PR TITLE
Restore borders for VEX upload card

### DIFF
--- a/src/components/vex-rules/VexUploadModal.tsx
+++ b/src/components/vex-rules/VexUploadModal.tsx
@@ -302,7 +302,7 @@ const VexUploadModal: FunctionComponent<VexUploadModalProps> = ({
                     onClick={() => {
                       carouselApi?.scrollTo(1);
                     }}
-                    className="cursor-pointer hover:border hover:border-primary border border-transparent"
+                    className="cursor-pointer hover:border-primary"
                   >
                     <CardHeader data-testid="upload-vex-file">
                       <CardTitle className="text-lg flex items-center gap-2 leading-tight">
@@ -320,7 +320,7 @@ const VexUploadModal: FunctionComponent<VexUploadModalProps> = ({
                     onClick={() => {
                       carouselApi?.scrollTo(2);
                     }}
-                    className="cursor-pointer hover:border hover:border-primary border border-transparent"
+                    className="cursor-pointer hover:border-primary"
                   >
                     <CardHeader>
                       <CardTitle className="text-lg flex items-center gap-2 leading-tight">


### PR DESCRIPTION
This pull request makes small adjustments to the styling of buttons in the `VexUploadModal` component to [fix this issue](https://github.com/l3montree-dev/devguard/issues/2342)

<img width="1200" height="900" alt="image" src="https://github.com/user-attachments/assets/d865fecd-fdb8-4bde-abaf-cf02bd98bbcf" />
