### PR TITLE
feat: added assetNames to downloads of sbom and vex

### DIFF
--- a/src/components/common/DelayedDownloadButton.tsx
+++ b/src/components/common/DelayedDownloadButton.tsx
@@ -8,6 +8,7 @@ interface DelayedDownloadButtonProps {
   label: string;
   className?: string;
   "data-testid"?: string;
+  downloadFileName?: string;
 }
 
 export function DelayedDownloadButton({
@@ -16,6 +17,7 @@ export function DelayedDownloadButton({
   label,
   className = "",
   "data-testid": dataTestId,
+  downloadFileName,
 }: DelayedDownloadButtonProps) {
   const [loading, setLoading] = useState(false);
 
@@ -29,7 +31,7 @@ export function DelayedDownloadButton({
       const parts = href.split("/");
       const filename = parts[parts.length - 1].split("?")[0];
 
-      link.download = filename;
+      link.download = downloadFileName ?? filename;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);

--- a/src/components/dependencies/SbomDownloadModal.tsx
+++ b/src/components/dependencies/SbomDownloadModal.tsx
@@ -60,6 +60,9 @@ export default function SbomDownloadModal({
     (artifacts ?? []).map((a) => a.artifactName),
   );
 
+  const jsonFileName = `${assetName}_sbom.json`
+  const xmlFileName = `${assetName}_sbom.xml`
+
   return (
     <Dialog open={showSBOMModal}>
       <DialogContent setOpen={setShowSBOMModal}>
@@ -116,6 +119,7 @@ export default function SbomDownloadModal({
               />
             }
             label={"Download in JSON-Format"}
+            downloadFileName={jsonFileName}
           />
           <DelayedDownloadButton
             href={
@@ -126,6 +130,7 @@ export default function SbomDownloadModal({
             }
             icon={<FileCode className="h-5 w-auto inline-block text-success" />}
             label={"Download in XML-Format"}
+            downloadFileName={xmlFileName}
           />
         </div>
         <hr className="mt-6" />

--- a/src/components/dependencies/VexDownloadModal.tsx
+++ b/src/components/dependencies/VexDownloadModal.tsx
@@ -60,6 +60,9 @@ export default function VexDownloadModal({
     (artifacts ?? []).map((a) => a.artifactName),
   );
 
+  const jsonFileName = `${assetName}_vex.json`
+  const xmlFileName = `${assetName}_vex.xml`
+
   return (
     <Dialog open={showVexModal}>
       <DialogContent setOpen={setShowVexModal}>
@@ -123,6 +126,7 @@ export default function VexDownloadModal({
               />
             }
             label={"Download in JSON-Format"}
+            downloadFileName={jsonFileName}
           />
           <DelayedDownloadButton
             href={
@@ -133,6 +137,7 @@ export default function VexDownloadModal({
             }
             icon={<FileCode className="h-5 w-auto inline-block text-success" />}
             label={"Download in XML-Format"}
+            downloadFileName={xmlFileName}
           />
         </div>
         <hr className="mt-6" />


### PR DESCRIPTION
The download of sbom & vex are now name specific to the asset.

<img width="311" height="107" alt="Bildschirmfoto 2026-07-13 um 10 46 14" src="https://github.com/user-attachments/assets/98d15c0b-45d6-433d-8493-c23e9e3e3104" />
