### PR TITLE
Fix dependency risks loading spinner position

### DIFF
--- a/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/page.tsx
+++ b/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/page.tsx
@@ -499,15 +499,14 @@ const Index: FunctionComponent = () => {
                 placeholder: "Search or filter results...",
               }}
             />
-            <div className="absolute right-2 top-1/2 -translate-y-1/2 ">
-              {isLoading && (
-                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-              )}
-            </div>
           </div>
         </div>
       </Section>
-      {!vulns?.data?.length ? (
+      {isLoading ? (
+        <div className="flex min-h-64 items-center justify-center">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        </div>
+      ) : !vulns?.data?.length ? (
         <div>
           <EmptyParty
             title="No matching results."


### PR DESCRIPTION
## Summary
- move the dependency risks loading spinner out of the filter row
- center it in the loading list
- hide stale results and the empty state while loading

## Testing
- `npx tsc --noEmit --pretty false`

Fixes l3montree-dev/devguard#2344