### PR TITLE
Render affected artifacts as dependency graph roots

### DIFF
--- a/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
+++ b/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
@@ -440,7 +440,7 @@ const Index: FunctionComponent = () => {
     ).sort((a, b) => a.localeCompare(b));
 
     if (artifactNames.length === 0) {
-      return [vuln.vulnerabilityPath];
+      return [["ROOT", ...vuln.vulnerabilityPath]];
     }
 
     return artifactNames.map((artifactName) => [

--- a/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
+++ b/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
@@ -430,13 +430,32 @@ const Index: FunctionComponent = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [graphLoading, shouldStartTour]);
 
-  const graphData = useMemo<ViewDependencyTreeNode | null>(() => {
+  const graphPaths = useMemo(() => {
     if (!vuln || vuln.vulnerabilityPath.length === 0) {
+      return [];
+    }
+
+    const artifactNames = Array.from(
+      new Set(vuln.artifacts.map((artifact) => artifact.artifactName)),
+    ).sort((a, b) => a.localeCompare(b));
+
+    if (artifactNames.length === 0) {
+      return [vuln.vulnerabilityPath];
+    }
+
+    return artifactNames.map((artifactName) => [
+      `artifact:${artifactName}`,
+      ...vuln.vulnerabilityPath,
+    ]);
+  }, [vuln]);
+
+  const graphData = useMemo<ViewDependencyTreeNode | null>(() => {
+    if (!vuln || graphPaths.length === 0) {
       return null;
     }
 
-    return convertPathsToTree([vuln.vulnerabilityPath], [vuln]);
-  }, [vuln]);
+    return convertPathsToTree(graphPaths, [vuln]);
+  }, [graphPaths, vuln]);
 
   // Generate path pattern options for the user to select
   // Each option is a suffix of the vulnerability path with a count of matching paths
@@ -829,10 +848,7 @@ const Index: FunctionComponent = () => {
                               }
                               graph={graphData}
                               vulns={[vuln]}
-                              highlightPath={[
-                                "ROOT",
-                                ...vuln.vulnerabilityPath,
-                              ]}
+                              highlightPaths={graphPaths}
                               onVexSelect={createFalsePositive}
                               vexRules={vexRulesData}
                               onReady={handleGraphReady}

--- a/src/components/DependencyGraph.tsx
+++ b/src/components/DependencyGraph.tsx
@@ -82,6 +82,17 @@ function getPathSuffix(
   return path;
 }
 
+function isHighlightedEdge(
+  parentId: string,
+  childId: string,
+  highlightPaths: string[][],
+) {
+  return highlightPaths.some((path) => {
+    const parentIndex = path.indexOf(parentId);
+    return parentIndex !== -1 && path[parentIndex + 1] === childId;
+  });
+}
+
 // Types for the context menu
 type MenuType = "edge" | "node" | null;
 
@@ -114,6 +125,8 @@ const nodeTypes = {
   loadMoreNode: LoadMoreNode,
 };
 
+const EMPTY_HIGHLIGHT_PATHS: string[][] = [];
+
 const DependencyGraph: FunctionComponent<{
   width: number;
   height: number;
@@ -124,7 +137,7 @@ const DependencyGraph: FunctionComponent<{
   // Handler for context-menu VEX actions. Can be async and should return `true` if it handled the action
   // (for example by creating a false-positive rule). If it returns falsy / undefined, component will still close the menu.
   onVexSelect?: (selection: VexSelection) => Promise<boolean> | void;
-  highlightPath?: string[];
+  highlightPaths?: string[][];
   vexRules?: VexRule[];
   onReady?: () => void;
 }> = ({
@@ -135,7 +148,7 @@ const DependencyGraph: FunctionComponent<{
   variant,
   onVexSelect,
   enableContextMenu,
-  highlightPath,
+  highlightPaths,
   vexRules,
   onReady,
 }) => {
@@ -148,6 +161,9 @@ const DependencyGraph: FunctionComponent<{
 
   // Context menu state
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+
+  const pathsToHighlight = highlightPaths ?? EMPTY_HIGHLIGHT_PATHS;
+  const highlightPath = pathsToHighlight[0];
 
   // Pre-compute child counts for auto-expansion
   const childCountMapRef = useRef<Map<string, number>>(new Map());
@@ -228,8 +244,12 @@ const DependencyGraph: FunctionComponent<{
     );
     previousNodesRef.current = nodes;
 
-    // get the root node - we use it for the initial position of the viewport
-    const rootNode = nodes.find((n) => n.id === graph.id);
+    const graphRoot = nodes.find((node) => node.id === graph.id);
+    const visibleRoots = nodes
+      .filter((node) => graph.children.some((child) => child.id === node.id))
+      .sort((a, b) => a.position.y - b.position.y);
+    const rootNode =
+      graphRoot ?? visibleRoots[Math.floor(visibleRoots.length / 2)];
     return [nodes, edges, rootNode];
   }, [
     graph,
@@ -278,18 +298,14 @@ const DependencyGraph: FunctionComponent<{
     }
 
     for (const edge of initialEdges) {
-      // Check if edge is in highlight path
-      let isHighlightEdge = false;
-      if (highlightPath && highlightPath.length > 0) {
-        const parentIndex = highlightPath.indexOf(edge.target);
-        const childIndex = highlightPath.indexOf(edge.source);
-        isHighlightEdge =
-          parentIndex !== -1 &&
-          childIndex !== -1 &&
-          parentIndex === childIndex - 1;
-        if (isHighlightEdge) {
-          highlightPathEdges.add(edge.id);
-        }
+      // Check if edge is in one of the highlighted paths
+      const isHighlightEdge = isHighlightedEdge(
+        edge.target,
+        edge.source,
+        pathsToHighlight,
+      );
+      if (isHighlightEdge) {
+        highlightPathEdges.add(edge.id);
       }
 
       // Check if edge matches a VEX rule (false positive)
@@ -337,7 +353,7 @@ const DependencyGraph: FunctionComponent<{
       highlightPathEdges,
       falsePositiveEdges,
     };
-  }, [initialEdges, highlightPath, vexRules]);
+  }, [initialEdges, pathsToHighlight, vexRules]);
 
   useEffect(() => {
     setNodes(initialNodes);
@@ -345,16 +361,7 @@ const DependencyGraph: FunctionComponent<{
     const styledEdges = initialEdges.map((edge) => {
       const isFp = edgeMaps.falsePositiveEdges.has(edge.id);
 
-      // Check if this edge is part of the vulnerability path
-      let isInPath = false;
-      if (highlightPath && highlightPath.length > 0) {
-        const parentIndex = highlightPath.indexOf(edge.target);
-        const childIndex = highlightPath.indexOf(edge.source);
-        isInPath =
-          parentIndex !== -1 &&
-          childIndex !== -1 &&
-          parentIndex === childIndex - 1;
-      }
+      const isInPath = edgeMaps.highlightPathEdges.has(edge.id);
 
       if (isFp) {
         return {
@@ -403,7 +410,7 @@ const DependencyGraph: FunctionComponent<{
     rootNode,
     height,
     width,
-    highlightPath,
+    edgeMaps.highlightPathEdges,
     edgeMaps.falsePositiveEdges,
   ]);
 
@@ -581,8 +588,8 @@ const DependencyGraph: FunctionComponent<{
 
       const pathEdgeIds = new Set<string>();
 
-      // When a highlight path is active, only highlight the single hovered edge (and only if it's blue)
-      if (highlightPath && highlightPath.length > 0) {
+      // When highlight paths are active, only highlight the hovered path edge.
+      if (pathsToHighlight.length > 0) {
         if (!edgeMaps.highlightPathEdges.has(edge.id)) return;
         pathEdgeIds.add(edge.id);
         applyHoverHighlight(pathEdgeIds);
@@ -617,7 +624,7 @@ const DependencyGraph: FunctionComponent<{
 
       applyHoverHighlight(pathEdgeIds);
     },
-    [edgeMaps, applyHoverHighlight, highlightPath, enableContextMenu],
+    [edgeMaps, applyHoverHighlight, pathsToHighlight, enableContextMenu],
   );
 
   const handleEdgeMouseLeave = useCallback(() => {

--- a/src/components/DependencyGraph.tsx
+++ b/src/components/DependencyGraph.tsx
@@ -82,17 +82,6 @@ function getPathSuffix(
   return path;
 }
 
-function isHighlightedEdge(
-  parentId: string,
-  childId: string,
-  highlightPaths: string[][],
-) {
-  return highlightPaths.some((path) => {
-    const parentIndex = path.indexOf(parentId);
-    return parentIndex !== -1 && path[parentIndex + 1] === childId;
-  });
-}
-
 // Types for the context menu
 type MenuType = "edge" | "node" | null;
 
@@ -164,6 +153,17 @@ const DependencyGraph: FunctionComponent<{
 
   const pathsToHighlight = highlightPaths ?? EMPTY_HIGHLIGHT_PATHS;
   const highlightPath = pathsToHighlight[0];
+  const highlightAdjacency = useMemo(() => {
+    const adjacency = new Map<string, Set<string>>();
+    for (const path of pathsToHighlight) {
+      for (let i = 0; i < path.length - 1; i++) {
+        const children = adjacency.get(path[i]) ?? new Set<string>();
+        children.add(path[i + 1]);
+        adjacency.set(path[i], children);
+      }
+    }
+    return adjacency;
+  }, [pathsToHighlight]);
 
   // Pre-compute child counts for auto-expansion
   const childCountMapRef = useRef<Map<string, number>>(new Map());
@@ -299,11 +299,8 @@ const DependencyGraph: FunctionComponent<{
 
     for (const edge of initialEdges) {
       // Check if edge is in one of the highlighted paths
-      const isHighlightEdge = isHighlightedEdge(
-        edge.target,
-        edge.source,
-        pathsToHighlight,
-      );
+      const isHighlightEdge =
+        highlightAdjacency.get(edge.target)?.has(edge.source) ?? false;
       if (isHighlightEdge) {
         highlightPathEdges.add(edge.id);
       }
@@ -353,7 +350,7 @@ const DependencyGraph: FunctionComponent<{
       highlightPathEdges,
       falsePositiveEdges,
     };
-  }, [initialEdges, pathsToHighlight, vexRules]);
+  }, [initialEdges, highlightAdjacency, vexRules]);
 
   useEffect(() => {
     setNodes(initialNodes);

--- a/src/hooks/useCreateVexRule.test.ts
+++ b/src/hooks/useCreateVexRule.test.ts
@@ -37,6 +37,15 @@ describe("buildVexPathPattern", () => {
         "*",
       ]);
     });
+
+    it("does not create rules for structural nodes", () => {
+      const selection: VexSelection = {
+        type: "node",
+        justification: "not_present",
+        path: ["artifact:scanner", "pkg:golang/vuln-lib"],
+      };
+      expect(buildVexPathPattern(selection)).toBeNull();
+    });
   });
 
   describe("edge selection", () => {
@@ -65,6 +74,20 @@ describe("buildVexPathPattern", () => {
         "*",
         "pkg:golang/a",
         "pkg:golang/b",
+        "pkg:golang/vuln-lib",
+      ]);
+    });
+
+    it("excludes structural nodes from the dependency path", () => {
+      const selection: VexSelection = {
+        type: "edge",
+        justification: "does_not_call_vulnerable_function",
+        path: ["artifact:scanner", "pkg:golang/middle", "pkg:golang/vuln-lib"],
+        childIndex: 1,
+      };
+      expect(buildVexPathPattern(selection)).toEqual([
+        "*",
+        "pkg:golang/middle",
         "pkg:golang/vuln-lib",
       ]);
     });

--- a/src/hooks/useCreateVexRule.ts
+++ b/src/hooks/useCreateVexRule.ts
@@ -31,15 +31,25 @@ const labelMap: Record<string, string> = {
   uncontrollable_by_attacker: "Uncontrollable by Attacker",
 };
 
+const isStructuralGraphNode = (node: string) =>
+  node === "ROOT" || node.startsWith("artifact:");
+
 // Builds the path pattern array for a VEX rule from a user selection.
 // Node selections use ["*", node, "*"] to match regardless of position.
 // Edge selections use ["*", ...suffix] to match the specific dependency chain.
 export function buildVexPathPattern(selection: VexSelection): string[] | null {
   if (!selection.path || selection.path.length === 0) return null;
   if (selection.type === "node") {
-    return ["*", selection.path[0], "*"];
+    const selectedNode = selection.path[0];
+    return isStructuralGraphNode(selectedNode)
+      ? null
+      : ["*", selectedNode, "*"];
   }
-  return ["*", ...selection.path];
+
+  const componentPath = selection.path.filter(
+    (node) => !isStructuralGraphNode(node),
+  );
+  return componentPath.length === 0 ? null : ["*", ...componentPath];
 }
 
 // Returns an async handler that accepts the VEX selection and creates a false positive rule

--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -10,6 +10,14 @@ describe("beautifyPurl", () => {
       "@ory/integrations",
     );
   });
+
+  it("displays artifact nodes without their internal prefix", () => {
+    expect(beautifyPurl("artifact:scanner")).toBe("scanner");
+  });
+
+  it("displays an empty artifact name as the default artifact", () => {
+    expect(beautifyPurl("artifact:")).toBe("Default");
+  });
 });
 
 describe("extractPurlQualifiers", () => {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -170,6 +170,9 @@ export const beautifyPurl = (purl: string): string => {
   if (!purl) {
     return "";
   }
+  if (purl.startsWith("artifact:")) {
+    return purl.slice("artifact:".length) || "Default";
+  }
   try {
     const p = PackageURL.fromString(purl);
     return p.namespace ? `${p.namespace}/${p.name}` : p.name;

--- a/src/utils/dependencyGraphHelpers.test.ts
+++ b/src/utils/dependencyGraphHelpers.test.ts
@@ -1,0 +1,58 @@
+import {
+  convertPathsToTree,
+  getLayoutedElements,
+} from "./dependencyGraphHelpers";
+
+const dependency = "pkg:npm/example@1.0.0";
+
+const createArtifactGraph = () =>
+  convertPathsToTree(
+    [
+      ["artifact:api", dependency],
+      ["artifact:web", dependency],
+    ],
+    [],
+  );
+
+describe("artifact dependency graphs", () => {
+  it("connects every artifact to the shared dependency path", () => {
+    const graph = createArtifactGraph();
+
+    expect(graph.children.map((child) => child.name).sort()).toEqual([
+      "artifact:api",
+      "artifact:web",
+    ]);
+    expect(graph.children[0].children[0]).toBe(graph.children[1].children[0]);
+    expect(graph.children[0].children[0].parents).toHaveLength(2);
+  });
+
+  it("renders artifacts as graph roots instead of the synthetic root", () => {
+    const graph = createArtifactGraph();
+    const [nodes, edges] = getLayoutedElements(
+      graph,
+      [],
+      "LR",
+      300,
+      75,
+      new Set(["ROOT", "artifact:api", "artifact:web"]),
+      new Map(),
+      [],
+      undefined,
+      false,
+      undefined,
+    );
+
+    expect(nodes.map((node) => node.id).sort()).toEqual([
+      "artifact:api",
+      "artifact:web",
+      dependency,
+    ]);
+    expect(edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ target: "artifact:api", source: dependency }),
+        expect.objectContaining({ target: "artifact:web", source: dependency }),
+      ]),
+    );
+    expect(edges.some((edge) => edge.target === "ROOT")).toBe(false);
+  });
+});

--- a/src/utils/dependencyGraphHelpers.ts
+++ b/src/utils/dependencyGraphHelpers.ts
@@ -271,19 +271,30 @@ export const getLayoutedElements = (
   // Pre-populate child counts for all nodes
   populateChildCounts(tree, childCountMap);
 
-  addRecursive(
-    dagreGraph,
-    tree,
-    nodeWidth,
-    nodeHeight,
-    infoSourceMap,
-    expandedNodes,
-    childCountMap,
-    childrenLimitMap,
-    riskMap,
-    new Set(),
-    nameMap,
-  );
+  const hasArtifactRoots =
+    tree.nodeType === "root" &&
+    tree.children.length > 0 &&
+    tree.children.every((child) => child.nodeType === "artifact");
+  const rootsToRender = hasArtifactRoots ? tree.children : [tree];
+  const visited = new Set<string>();
+
+  [...rootsToRender]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .forEach((root) => {
+      addRecursive(
+        dagreGraph,
+        root,
+        nodeWidth,
+        nodeHeight,
+        infoSourceMap,
+        expandedNodes,
+        childCountMap,
+        childrenLimitMap,
+        riskMap,
+        visited,
+        nameMap,
+      );
+    });
 
   dagre.layout(dagreGraph, { width: 10, height: 10 });
 


### PR DESCRIPTION
## What this fixes

Dependency vulnerability graphs currently begin at the synthetic “Your application” node. That hides which artifacts actually contain the vulnerable dependency path, especially when the same path belongs to several artifacts.

This change renders every affected artifact as an entry point into the graph and connects each one to the shared dependency path.

## Design

- Build one graph path per unique artifact from the vulnerability’s existing `artifacts` relation. The paths are sorted for deterministic layout and merged through the existing tree conversion, so shared dependency nodes are not duplicated.
- Keep the synthetic root in the view model, where it is still useful for traversal and risk propagation, but omit it from layout when all of its children are artifact nodes. Graphs without artifact metadata retain their current root behavior and highlighting.
- Allow the graph to highlight multiple paths. Highlight adjacency is calculated once when the paths change, making each edge lookup constant time even with many artifacts.
- Keep VEX rules component-based by removing synthetic root and artifact entries from edge selections. Structural nodes themselves cannot create node rules, preventing rules that have no effect.
- Strip the internal `artifact:` identifier prefix only when formatting labels. Empty artifact names use the existing “Default” terminology.

## Tests

- Added coverage for several artifacts sharing one dependency path.
- Added coverage proving artifact nodes replace the synthetic rendered root.
- Added artifact label formatting coverage, including the default artifact.
- Added VEX path-pattern coverage for artifact-rooted paths and structural node selections.
- `bun test src/hooks/useCreateVexRule.test.ts src/utils/dependencyGraphHelpers.test.ts src/utils/common.test.ts`
- `npm run build`

Fixes https://github.com/l3montree-dev/devguard/issues/2416