### PR TITLE
Fix user avatar fallback initials display in RiskAssessmentFeed.tsx, …

### DIFF
--- a/src/components/risk-assessment/RiskAssessmentFeed.tsx
+++ b/src/components/risk-assessment/RiskAssessmentFeed.tsx
@@ -262,7 +262,13 @@ const RiskFeedItem = ({
                   <AvatarImage src={user?.avatarUrl} alt={event.userId} />
                 )}
                 <AvatarFallback className="bg-secondary">
-                  {user.realName.charAt(0)}
+                  {user.realName
+                    .trim()
+                    .split(/\s+/)
+                    .map((name) => name[0])
+                    .slice(0, 2)
+                    .join("")
+                    .toUpperCase()}
                 </AvatarFallback>
               </Avatar>
             )}

--- a/src/components/risk-assessment/RiskAssessmentFeed.tsx
+++ b/src/components/risk-assessment/RiskAssessmentFeed.tsx
@@ -262,13 +262,7 @@ const RiskFeedItem = ({
                   <AvatarImage src={user?.avatarUrl} alt={event.userId} />
                 )}
                 <AvatarFallback className="bg-secondary">
-                  {user.realName
-                    .trim()
-                    .split(/\s+/)
-                    .map((name) => name[0])
-                    .slice(0, 2)
-                    .join("")
-                    .toUpperCase()}
+                  {user.realName.charAt(0)}
                 </AvatarFallback>
               </Avatar>
             )}

--- a/src/utils/view.ts
+++ b/src/utils/view.ts
@@ -25,6 +25,7 @@ import type {
 import { type Identity } from "@ory/client-fetch";
 import { externalProviderIdToIntegrationName } from "./externalProvider";
 import { config } from "../config";
+import { getUserFullName, type User } from "@/types/auth";
 export const eventMessages = (event: VulnEventDTO) => {
   switch (event.type) {
     case "mitigate":
@@ -295,11 +296,11 @@ export const findUser = (
     };
   }
   if (currentUser?.id === id) {
+    const fullName = getUserFullName(currentUser as unknown as User);
     return {
       displayName: "You",
       avatarUrl: currentUser.traits?.picture,
-      realName:
-        currentUser.traits?.name.first + " " + currentUser.traits?.name.last,
+      realName: fullName || currentUser.traits?.email || "You",
     };
   }
   const user = org?.members.find((u) => u.id === id);


### PR DESCRIPTION
Fixed RiskAssessmentFeed default Icon is an "U" but should be user initals
https://github.com/l3montree-dev/devguard/issues/2653

The issue was that the avatar fallback only used user.realName.charAt(0), so users without an avatar only showed one letter. Changed it to generate initials from the user name by taking the first letter of up to two name parts and converting them to uppercase.

While checking the issue I also looked into the findUser helper. It can return "Unknown" when the user ID from the event does not match any organization member or current user. I did not change this logic because I could not confirm this was the cause without a working backend/Ory environment, but it may be related to cases where the wrong user data is received.the file name is view.ts

I could not fully test the application locally because the frontend requires the backend and Ory services to run. The change was tested by checking the frontend code path and formatting/linting requirements. if need more detials ask.