### PR TITLE
add potential package qualifiers to insights table

### DIFF
--- a/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependencies/page.tsx
+++ b/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependencies/page.tsx
@@ -39,6 +39,8 @@ import {
   beautifyPurl,
   classNames,
   extractVersion,
+  extractPurlQualifiers,
+  formatPurlQualifiers,
   licenses,
 } from "@/utils/common";
 import { buildFilterSearchParams } from "@/utils/url";
@@ -257,8 +259,13 @@ const columnsDef: ColumnDef<
               <span className="font-medium truncate w-full">
                 {beautifyPurl(row.getValue())}
               </span>
-              <span className="text-xs text-muted-foreground">
-                {extractVersion(row.getValue())}
+              <span className="flex min-w-0 flex-row items-center gap-2 text-xs text-muted-foreground">
+                <span>{extractVersion(row.getValue())}</span>
+                {extractPurlQualifiers(row.getValue()) && (
+                  <span className="max-w-64 truncate whitespace-nowrap">
+                    {formatPurlQualifiers(row.getValue())}
+                  </span>
+                )}
               </span>
             </span>
           </TooltipTrigger>


### PR DESCRIPTION

<img width="681" height="629" alt="purl_qualifiers" src="https://github.com/user-attachments/assets/a16ee57b-80c9-4677-802f-5fcb0f1f8e4b" />


Addresses [#2089](https://github.com/l3montree-dev/devguard/issues/2089)

Adds potential package qualifiers behind the version in the dependency insights table, just like already implemented in the dependency-risk view.

Full PURL is already shown on hover over an item in dependency insights, so another hover tooltip just for the package qualifiers like dependency-risk has, was skipped here, and only the qualifiers added behind the version inline.

Used gap-2 like dependency-risk already has to make it slightly distinct from the version so skimming over the list looking for a specific package version is easier without getting distracted by potential qualifiers.