### PR TITLE
Fix API URL concatenation in group settings

### DIFF
--- a/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/settings/page.tsx
+++ b/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/settings/page.tsx
@@ -255,7 +255,7 @@ These identifiers are managed by the external system and are treated as immutabl
             <CopyInput
               value={
                 config.devguardApiUrlPublicInternet +
-                "api/v1" +
+                "/api/v1" +
                 "/organizations/" +
                 activeOrg.slug +
                 "/projects/" +


### PR DESCRIPTION
This is currently broken:

<img width="357" height="131" alt="image" src="https://github.com/user-attachments/assets/cce685c6-820c-4408-9953-ba2bd19ba6cc" />
