### PR TITLE
Focuses organization name during setup

### DIFF
--- a/src/components/OrgForm.test.tsx
+++ b/src/components/OrgForm.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+
+import { OrgForm } from "./OrgForm";
+import { Form } from "./ui/form";
+
+jest.mock("@/hooks/useActiveOrg", () => ({
+  useActiveOrg: () => undefined,
+}));
+
+function renderOrgForm(autoFocus?: boolean) {
+  function TestForm() {
+    const form = useForm<{ name: string }>({
+      defaultValues: { name: "" },
+    });
+
+    return (
+      <Form {...form}>
+        <OrgForm autoFocus={autoFocus} />
+      </Form>
+    );
+  }
+
+  render(<TestForm />);
+  return screen.getByRole("textbox", { name: "Organization name*" });
+}
+
+describe("OrgForm", () => {
+  it("focuses the organization name during setup", () => {
+    expect(renderOrgForm(true)).toHaveFocus();
+  });
+
+  it("does not focus the organization name by default", () => {
+    expect(renderOrgForm()).not.toHaveFocus();
+  });
+});

--- a/src/components/OrgForm.tsx
+++ b/src/components/OrgForm.tsx
@@ -12,9 +12,11 @@ import { InputWithButton } from "./ui/input-with-button";
 import { useActiveOrg } from "@/hooks/useActiveOrg";
 
 interface OrgFormProps {
+  autoFocus?: boolean;
   forceVertical?: boolean;
 }
 export const OrgForm: FunctionComponent<OrgFormProps> = ({
+  autoFocus = false,
   forceVertical = true,
 }) => {
   const activeOrg = useActiveOrg();
@@ -39,7 +41,11 @@ export const OrgForm: FunctionComponent<OrgFormProps> = ({
             <FormItem>
               <FormLabel>Organization name*</FormLabel>
               <FormControl>
-                <Input data-testid="org-name-label" {...field} />
+                <Input
+                  autoFocus={autoFocus}
+                  data-testid="org-name-label"
+                  {...field}
+                />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/components/OrgRegister.tsx
+++ b/src/components/OrgRegister.tsx
@@ -75,7 +75,7 @@ export default function OrgRegisterForm() {
         className="text-black dark:text-white"
         onSubmit={form.handleSubmit(handleOrgCreation)}
       >
-        <OrgForm />
+        <OrgForm autoFocus />
 
         <div className="mt-6 flex items-center justify-end gap-x-3">
           <Button


### PR DESCRIPTION
Focus the organization name field when the setup form opens. The shared form stays opt-in, so settings pages keep their current focus behavior.

Adds coverage for both cases.

Closes l3montree-dev/devguard#2715

Tested with:
- `npm test -- --ci` (31 tests)
- `npx tsc --noEmit`
- `npm run build`