### PR TITLE
conditionally render checkbox instead of disabling

### DIFF
--- a/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/code-risks/page.tsx
+++ b/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/code-risks/page.tsx
@@ -474,21 +474,22 @@ const Index: FunctionComponent = () => {
                       <tr key={headerGroup.id}>
                         <AuthGuard require="member">
                           <th className="w-10 p-4 text-left">
-                            <div onClick={(e) => e.stopPropagation()}>
-                              <Checkbox
-                                checked={
-                                  allPageSelected
-                                    ? true
-                                    : somePageSelected
-                                      ? "indeterminate"
-                                      : false
-                                }
-                                onCheckedChange={() =>
-                                  handleToggleAll(pageSelectableIds)
-                                }
-                                disabled={pageSelectableIds.length === 0}
-                              />
-                            </div>
+                            {pageSelectableIds.length > 0 && (
+                              <div onClick={(e) => e.stopPropagation()}>
+                                <Checkbox
+                                  checked={
+                                    allPageSelected
+                                      ? true
+                                      : somePageSelected
+                                        ? "indeterminate"
+                                        : false
+                                  }
+                                  onCheckedChange={() =>
+                                    handleToggleAll(pageSelectableIds)
+                                  }
+                                />
+                              </div>
+                            )}
                           </th>
                         </AuthGuard>
                         {headerGroup.headers.map((header) => (


### PR DESCRIPTION
Addresses [#2595](https://github.com/l3montree-dev/devguard/issues/2595)

Checkbox does not get rendered if there is nothing selectable, instead of only disabling it.

<img width="1095" height="271" alt="Bildschirmfoto 2026-07-31 um 16 15 28" src="https://github.com/user-attachments/assets/71102f8d-eca4-4fc7-bd5d-dae100de48fd" />