### PR TITLE
add link icon, truncate name to fix overflow

### DIFF
--- a/src/components/organization/MostUsedComponents.tsx
+++ b/src/components/organization/MostUsedComponents.tsx
@@ -7,10 +7,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid"
 import { beautifyPurl, extractVersion } from "@/utils/common";
 import EcosystemImage from "../common/EcosystemImage";
 import Link from "next/link";
 import { documentationLinks } from "@/const/documentationLinks";
+import { truncateMiddle } from "@/utils/common"
 
 interface Props {
   topComponents: ComponentUsageInOrg[];
@@ -63,9 +65,12 @@ const MostUsedComponents: FunctionComponent<Props> = ({ topComponents }) => {
                             )}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="truncate !text-foreground"
+                            className="inline-flex min-w-0 items-center gap-1 !text-foreground"
                           >
-                            {beautifyPurl(entry.purl)}
+                            <span className="truncate">
+                              {truncateMiddle(beautifyPurl(entry.purl), 45)}
+                            </span>
+                            <ArrowTopRightOnSquareIcon className="h-[1em] w-[1em] shrink-0" />
                           </Link>
                           {version && (
                             <span className="text-xs text-muted-foreground">


### PR DESCRIPTION
Addresses [#2726](https://github.com/l3montree-dev/devguard/issues/2726)

Added icon behind component name to make it more clear that it's an outbound link to the documentation package inspector page as asked for in the issue.

Additionally, the table overflowed when there are long component names as these were not truncated properly, which was fixed.

Before:

<img width="586" height="448" alt="Overflow-before" src="https://github.com/user-attachments/assets/3e62de8c-a59f-4aca-9843-37e8866db2cb" />

After:

<img width="587" height="452" alt="Table-fixed" src="https://github.com/user-attachments/assets/bb917e7e-55c5-451d-a8d1-312d68dce4b4" />
