### PR TITLE
fix: scan-carousel-fixes

### DIFF
--- a/src/components/RiskScannerDialog.tsx
+++ b/src/components/RiskScannerDialog.tsx
@@ -591,7 +591,6 @@ const RiskScannerDialog: FunctionComponent<RiskScannerDialogProps> = ({
               api={api}
               selectedSetup={selectedSetup}
               setSelectedSetup={setSelectedSetup}
-              prevIndex={prevIndex}
               informationSourceSlideIndex={15}
               devguardCliSlideIndex={16}
               devguardToolsSlideIndex={7}
@@ -650,6 +649,7 @@ const RiskScannerDialog: FunctionComponent<RiskScannerDialogProps> = ({
               api={api}
               cliSlideIndex={12}
               fileUploadSlideIndex={13}
+              prevIndex={prevIndex}
             />
             <AutomatedIntegrationSlide
               apiUrl={apiUrl}

--- a/src/components/guides/risk-scanner-carousel-slides/AutomatedIntegrationSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/AutomatedIntegrationSlide.tsx
@@ -117,6 +117,13 @@ const AutomatedIntegrationSlide: FunctionComponent<
         <AccessTokenSection description="Risk Identification using CLI Setup" />
       </div>
       <div className="mt-10 flex flex-row gap-2 justify-end">
+        <Button
+          variant={"secondary"}
+          id="devguard-cli-scan-back-to-selection"
+          onClick={() => api?.scrollTo(prevIndex)}
+          >
+          Back
+        </Button>
         <Button id="automated-integration-continue" onClick={onClose}>
           Finish Setup
         </Button>

--- a/src/components/guides/risk-scanner-carousel-slides/AutomatedIntegrationSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/AutomatedIntegrationSlide.tsx
@@ -119,7 +119,7 @@ const AutomatedIntegrationSlide: FunctionComponent<
       <div className="mt-10 flex flex-row gap-2 justify-end">
         <Button
           variant={"secondary"}
-          id="devguard-cli-scan-back-to-selection"
+          id="automated-integration-back-to-selection"
           onClick={() => api?.scrollTo(prevIndex)}
           >
           Back

--- a/src/components/guides/risk-scanner-carousel-slides/DevGuardCliSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/DevGuardCliSlide.tsx
@@ -139,7 +139,7 @@ ${generateDockerSnippet(scannerImage, "sast", org.slug, project.slug, asset.slug
         <div className="mt-0 flex flex-wrap flex-row gap-2 justify-end">
           <Button
             variant={"secondary"}
-            id="install-devguard-cli-back-to-selection"
+            id="devguard-cli-scan-back-to-selection"
             onClick={() => api?.scrollTo(prevIndex)}
           >
             Back

--- a/src/components/guides/risk-scanner-carousel-slides/DevGuardCliSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/DevGuardCliSlide.tsx
@@ -137,6 +137,13 @@ ${generateDockerSnippet(scannerImage, "sast", org.slug, project.slug, asset.slug
         </Tabs>
 
         <div className="mt-0 flex flex-wrap flex-row gap-2 justify-end">
+          <Button
+            variant={"secondary"}
+            id="install-devguard-cli-back-to-selection"
+            onClick={() => api?.scrollTo(prevIndex)}
+          >
+            Back
+          </Button>
           <Button id="install-devguard-cli-finish" onClick={onClose}>
             Finish
           </Button>

--- a/src/components/guides/risk-scanner-carousel-slides/IntegrationMethodSelectionSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/IntegrationMethodSelectionSlide.tsx
@@ -21,6 +21,7 @@ import { Badge } from "../../ui/badge";
 import { Card, CardDescription, CardHeader, CardTitle } from "../../ui/card";
 import { CarouselItem } from "../../ui/carousel";
 import { DialogHeader, DialogTitle } from "../../ui/dialog";
+import { Button } from "../../ui/button";
 
 interface IntegrationMethodSelectionSlideProps {
   api?: {
@@ -29,11 +30,12 @@ interface IntegrationMethodSelectionSlideProps {
   setVariant: (variant: "manual" | "auto") => void;
   cliSlideIndex: number;
   fileUploadSlideIndex: number;
+  prevIndex: number;
 }
 
 const IntegrationMethodSelectionSlide: FunctionComponent<
   IntegrationMethodSelectionSlideProps
-> = ({ api, setVariant, cliSlideIndex, fileUploadSlideIndex }) => {
+> = ({ api, setVariant, cliSlideIndex, fileUploadSlideIndex, prevIndex }) => {
   return (
     <CarouselItem>
       <div className="">
@@ -84,6 +86,15 @@ const IntegrationMethodSelectionSlide: FunctionComponent<
               </CardDescription>
             </CardHeader>
           </Card>
+          <div className="mt-4 flex flex-row gap-2 justify-end">
+            <Button
+              variant={"secondary"}
+              id="integration-method-back-to-selection"
+              onClick={() => api?.scrollTo(prevIndex)}
+            >
+              Back
+            </Button>
+          </div>
         </div>
       </div>
     </CarouselItem>

--- a/src/components/guides/risk-scanner-carousel-slides/ScannerOptionsSelectionSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/ScannerOptionsSelectionSlide.tsx
@@ -512,7 +512,7 @@ const ScannerOptionsSelectionSlide: FunctionComponent<
       <div className="mt-4 flex flex-row gap-2 justify-end">
         <Button
             variant={"secondary"}
-            id="devguard-cli-scan-back-to-selection"
+            id="scanner-options-back-to-selection"
             onClick={() => api?.scrollTo(prevIndex)}
           >
             Back

--- a/src/components/guides/risk-scanner-carousel-slides/ScannerOptionsSelectionSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/ScannerOptionsSelectionSlide.tsx
@@ -509,7 +509,14 @@ const ScannerOptionsSelectionSlide: FunctionComponent<
         </div>
       </div>
 
-      <div className="mt-10 flex flex-row gap-2 justify-end">
+      <div className="mt-4 flex flex-row gap-2 justify-end">
+        <Button
+            variant={"secondary"}
+            id="devguard-cli-scan-back-to-selection"
+            onClick={() => api?.scrollTo(prevIndex)}
+          >
+            Back
+        </Button>
         <Button
           disabled={Object.values(config).every((v) => v === false)}
           id="scanner-options-selection-continue"

--- a/src/components/guides/risk-scanner-carousel-slides/ScannerSelectionSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/ScannerSelectionSlide.tsx
@@ -1,7 +1,6 @@
 import { CubeTransparentIcon } from "@heroicons/react/20/solid";
 import Image from "next/image";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   Card,
   CardDescription,
@@ -13,21 +12,22 @@ import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { classNames } from "@/utils/common";
 import { LinkIcon } from "@heroicons/react/24/outline";
 
+type Setup =
+  | "devguard-tools"
+  | "own-setup"
+  | "information-source"
+  | "devguard-cli";
+
 interface ScannerSelectionSlideProps {
   api?: {
     scrollTo: (index: number) => void;
   };
-  prevIndex: number;
-  selectedSetup?:
-    "devguard-tools" | "own-setup" | "information-source" | "devguard-cli";
+  selectedSetup?: Setup;
   devguardToolsSlideIndex: number;
   devguardCliSlideIndex: number;
   customSetupSlideIndex: number;
   informationSourceSlideIndex: number;
-  setSelectedSetup: (
-    setup:
-      "devguard-tools" | "own-setup" | "information-source" | "devguard-cli",
-  ) => void;
+  setSelectedSetup: (setup: Setup) => void;
 }
 
 export default function ScannerSelectionSlide({
@@ -38,8 +38,20 @@ export default function ScannerSelectionSlide({
   informationSourceSlideIndex,
   devguardToolsSlideIndex,
   customSetupSlideIndex,
-  prevIndex,
 }: ScannerSelectionSlideProps) {
+  const selectAndContinue = (setup: Setup) => {
+    setSelectedSetup(setup);
+    api?.scrollTo(
+      setup === "devguard-tools"
+        ? devguardToolsSlideIndex
+        : setup === "information-source"
+          ? informationSourceSlideIndex
+          : setup === "devguard-cli"
+            ? devguardCliSlideIndex
+            : customSetupSlideIndex,
+    );
+  };
+
   return (
     <CarouselItem>
       <DialogHeader>
@@ -51,7 +63,7 @@ export default function ScannerSelectionSlide({
             "cursor-pointer",
             selectedSetup === "devguard-tools" ? "border-primary" : "",
           )}
-          onClick={() => setSelectedSetup("devguard-tools")}
+          onClick={() => selectAndContinue("devguard-tools")}
         >
           <CardHeader>
             <CardTitle className="text-lg flex flex-row items-center leading-tight">
@@ -78,7 +90,7 @@ export default function ScannerSelectionSlide({
             "cursor-pointer mt-2",
             selectedSetup === "devguard-cli" ? "border-primary" : "",
           )}
-          onClick={() => setSelectedSetup("devguard-cli")}
+          onClick={() => selectAndContinue("devguard-cli")}
         >
           <CardHeader>
             <CardTitle className="text-lg flex flex-row items-center leading-tight">
@@ -106,7 +118,7 @@ export default function ScannerSelectionSlide({
             selectedSetup === "own-setup" ? "border-primary" : "",
           )}
           data-testid="own-setup-card"
-          onClick={() => setSelectedSetup("own-setup")}
+          onClick={() => selectAndContinue("own-setup")}
         >
           <CardHeader>
             <CardTitle className="text-lg items-center flex flex-row leading-tight">
@@ -131,7 +143,7 @@ export default function ScannerSelectionSlide({
             "cursor-pointer mt-2   ",
             selectedSetup === "information-source" ? "border-primary" : "",
           )}
-          onClick={() => setSelectedSetup("information-source")}
+          onClick={() => selectAndContinue("information-source")}
         >
           <CardHeader>
             <CardTitle className="text-lg items-center flex flex-row leading-tight">
@@ -147,34 +159,6 @@ export default function ScannerSelectionSlide({
             </CardDescription>
           </CardHeader>
         </Card>
-      </div>
-      <div className="mt-10 flex flex-wrap flex-row gap-2 justify-end">
-        <Button
-          variant={"secondary"}
-          data-testid="scanner-selection-back"
-          onClick={() => {
-            api?.scrollTo(prevIndex); // Back to SetupMethodSelectionSlide
-          }}
-        >
-          Back
-        </Button>
-        <Button
-          disabled={selectedSetup === undefined}
-          data-testid="scanner-selection-continue"
-          onClick={() => {
-            api?.scrollTo(
-              selectedSetup === "devguard-tools"
-                ? devguardToolsSlideIndex
-                : selectedSetup === "information-source"
-                  ? informationSourceSlideIndex
-                  : selectedSetup === "devguard-cli"
-                    ? devguardCliSlideIndex
-                    : customSetupSlideIndex,
-            ); // Forward to slide 3
-          }}
-        >
-          {selectedSetup === undefined ? "Select a Scanner" : "Continue"}
-        </Button>
       </div>
     </CarouselItem>
   );

--- a/src/components/guides/risk-scanner-carousel-slides/SetupInformationSourceSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/SetupInformationSourceSlide.tsx
@@ -38,9 +38,11 @@ export const SetupInformationSourceSlide: FunctionComponent<
   // this is necessary since we sometimes add a purl and thus the form object changes
   // we do this dynamically in the artifact form itself.
   const sourceURLs = sources.reduce((acc, curr) => acc + curr.url, "");
+  // validation messages change the slide height, otherwise the buttons get cut off
+  const errorFields = Object.keys(form.formState.errors).join(",");
   useEffect(() => {
     api?.reInit();
-  }, [api, sourceURLs]);
+  }, [api, sourceURLs, errorFields]);
 
   const handleSubmit = async (data: ArtifactCreateUpdateRequest) => {
     if (data.informationSources.length === 0) {
@@ -77,7 +79,15 @@ export const SetupInformationSourceSlide: FunctionComponent<
           onSubmit={form.handleSubmit(handleSubmit)}
         >
           <ArtifactForm form={form} isEditMode={false} />
-          <div className="mt-10 flex flex-wrap flex-row gap-2 justify-end">
+          <div className="mt-4 flex flex-wrap flex-row gap-2 justify-end">
+            <Button
+              variant={"secondary"}
+              type="button"
+              id="supplier-provided-sbom-back-to-selection"
+              onClick={() => api?.scrollTo(prevIndex)}
+            >
+              Back
+            </Button>
             <Button
               isSubmitting={form.formState.isSubmitting}
               id="setup-information-sources-create"

--- a/src/components/guides/risk-scanner-carousel-slides/SetupInformationSourceSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/SetupInformationSourceSlide.tsx
@@ -83,7 +83,7 @@ export const SetupInformationSourceSlide: FunctionComponent<
             <Button
               variant={"secondary"}
               type="button"
-              id="supplier-provided-sbom-back-to-selection"
+              id="setup-information-sources-back-to-selection"
               onClick={() => api?.scrollTo(prevIndex)}
             >
               Back

--- a/src/const/documentationLinks.ts
+++ b/src/const/documentationLinks.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: 	AGPL-3.0-or-later
 export const documentationLinks = {
   docsIntroduction: "https://devguard.org/introduction",
-  sbomExplaining: "https://devguard.org/explanations/explaining-sboms",
+  sbomExplaining: "https://docs.devguard.org/explanations/compliance/sbom-standards/",
   vexExplaining:
-    "https://devguard.org/explanations/compliance/csaf-vex-explained",
+    "https://docs.devguard.org/explanations/vulnerability-management/what-is-vex/",
   vexRecommendationWhitepaper:
     "https://devguard.org/research-development/vex-sharing-trust-based-knowledge-based-collaborative-share-vulnerability-management-decisions-in-devguard.pdf",
   artifactExplaining:


### PR DESCRIPTION
Addresses [#2720](https://github.com/l3montree-dev/devguard/issues/2720)

- Removed `Continue` and `Back` buttons from Identify Risk `ScannerSelectionSlide` for better UX
- Added Back buttons to all following slides
- fixed a bug that would cause the buttons to be cutoff due to the card not expanding after using the back button on `SetupInformationSourceSlide` due to the input warning getting rendered on navigation alone
- fixed 2 dead links to old documentation URLs that get used in `AutomatedIntegrationSlide`

E2E tests passed without being adjusted as they don't make use of the carousel and only jump directly to slides in setup, so I did not change any tests.