### PR TITLE
fix: prevent access token list duplication

### DIFF
--- a/src/hooks/usePersonalAccessToken.test.tsx
+++ b/src/hooks/usePersonalAccessToken.test.tsx
@@ -1,0 +1,110 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { EventEmitter } from "events";
+
+import { createPat } from "@/services/patService";
+import type {
+  AsymmetricPersonalAccessTokenDTO,
+  SeeOncePatWithPrivKey,
+} from "@/types/api/api";
+import usePersonalAccessToken from "./usePersonalAccessToken";
+
+jest.mock("@/services/patService", () => ({
+  createPat: jest.fn(),
+}));
+
+jest.mock("@/services/devGuardApi", () => ({
+  browserApiClient: jest.fn(),
+}));
+
+const tokenBase = (id: string) => ({
+  createdAt: "2026-08-09T00:00:00Z",
+  description: `Token ${id}`,
+  expiryDateUnix: 1_800_000_000,
+  id,
+  lastUsedAt: null,
+  scopes: "scan",
+  userId: "user-1",
+});
+
+const storedToken = (id: string): SeeOncePatWithPrivKey => ({
+  ...tokenBase(id),
+  privKey: `private-${id}`,
+});
+
+describe("usePersonalAccessToken", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("does not duplicate a stored token when the hook remounts", async () => {
+    const existingToken: AsymmetricPersonalAccessTokenDTO = {
+      ...tokenBase("pat-1"),
+      fingerprint: "fingerprint-1",
+      pubKey: "public-key-1",
+    };
+    sessionStorage.setItem("pat", JSON.stringify(storedToken("pat-1")));
+
+    const firstRender = renderHook(() =>
+      usePersonalAccessToken([existingToken]),
+    );
+    await waitFor(() => {
+      expect(firstRender.result.current.personalAccessTokens).toHaveLength(1);
+    });
+    firstRender.unmount();
+
+    const secondRender = renderHook(() =>
+      usePersonalAccessToken([existingToken]),
+    );
+    await waitFor(() => {
+      expect(
+        secondRender.result.current.personalAccessTokens.map(({ id }) => id),
+      ).toEqual(["pat-1"]);
+    });
+  });
+
+  it("keeps separately created tokens that do not have fingerprints", async () => {
+    const firstToken = storedToken("pat-1");
+    const secondToken = storedToken("pat-2");
+    const mockedCreatePat = createPat as jest.MockedFunction<typeof createPat>;
+    mockedCreatePat
+      .mockResolvedValueOnce(firstToken)
+      .mockResolvedValueOnce(secondToken);
+
+    const { result } = renderHook(() => usePersonalAccessToken());
+    const input = {
+      description: "CI token",
+      expiryDateUnix: 1_800_000_000,
+      scopes: "scan",
+      symmetric: false as const,
+    };
+
+    await act(async () => {
+      await result.current.onCreatePat(input);
+      await result.current.onCreatePat(input);
+    });
+
+    expect(result.current.personalAccessTokens.map(({ id }) => id)).toEqual([
+      "pat-1",
+      "pat-2",
+    ]);
+  });
+
+  it("unsubscribes from token events when the hook unmounts", () => {
+    const on = jest.spyOn(EventEmitter.prototype, "on");
+    const off = jest.spyOn(EventEmitter.prototype, "off");
+
+    const { unmount } = renderHook(() => usePersonalAccessToken());
+    const subscriptions = on.mock.calls.filter(([event]) => event === "pat");
+    const listener = subscriptions[subscriptions.length - 1]?.[1];
+    expect(listener).toEqual(expect.any(Function));
+
+    unmount();
+
+    expect(off).toHaveBeenCalledWith("pat", listener);
+  });
+});

--- a/src/hooks/usePersonalAccessToken.ts
+++ b/src/hooks/usePersonalAccessToken.ts
@@ -9,33 +9,45 @@ import type {
 } from "@/types/api/api";
 import { useEffect, useState, useRef } from "react";
 import { EventEmitter } from "events";
-import { uniqBy, isEqual } from "lodash";
+import { isEqual } from "lodash";
 
 const newPatEventEmitter = new EventEmitter();
+
+type AccessToken =
+  | AsymmetricPersonalAccessTokenDTO
+  | SymmetricPersonalAccessTokenDTO
+  | SeeOncePatWithPrivKey
+  | SeeOncePatWithBearerToken;
+
+const mergeAccessTokens = (tokens: AccessToken[]) => {
+  const tokensById = new Map<string, AccessToken>();
+  for (const token of tokens) {
+    tokensById.set(token.id, token);
+  }
+  return Array.from(tokensById.values());
+};
+
 export default function usePersonalAccessToken(
   existingPats?: Array<PersonalAccessTokenDTO>,
   baseUrl: string = "/pats/",
 ) {
   const [personalAccessTokens, setPersonalAccessTokens] = useState<
-    Array<
-      | AsymmetricPersonalAccessTokenDTO
-      | SymmetricPersonalAccessTokenDTO
-      | SeeOncePatWithPrivKey
-      | SeeOncePatWithBearerToken
-    >
+    AccessToken[]
   >(existingPats ?? []);
   const prevExistingPatsRef = useRef<Array<PersonalAccessTokenDTO> | undefined>(
     undefined,
   );
 
-  // ync with existingPats when SWR data loads or changes
+  // Sync with existingPats when SWR data loads or changes.
   useEffect(() => {
     if (existingPats && !isEqual(prevExistingPatsRef.current, existingPats)) {
       prevExistingPatsRef.current = existingPats;
       setPersonalAccessTokens((prev) => {
-        // merge existing pats with newly created ones (privKey)
-        const newlyCreated = prev.filter((p) => "privKey" in p);
-        return uniqBy([...existingPats, ...newlyCreated], "fingerprint");
+        // Keep see-once secrets until the user has had a chance to copy them.
+        const newlyCreated = prev.filter(
+          (pat) => "privKey" in pat || "bearerToken" in pat,
+        );
+        return mergeAccessTokens([...existingPats, ...newlyCreated]);
       });
     }
   }, [existingPats]);
@@ -46,11 +58,17 @@ export default function usePersonalAccessToken(
       const parsed = JSON.parse(pat) as
         SeeOncePatWithPrivKey | SeeOncePatWithBearerToken;
 
-      setPersonalAccessTokens((prev) => [...prev, parsed]);
+      setPersonalAccessTokens((prev) => mergeAccessTokens([...prev, parsed]));
     }
-    newPatEventEmitter.on("pat", (pat) => {
-      setPersonalAccessTokens((prev) => uniqBy([...prev, pat], "fingerprint"));
-    });
+
+    const handleNewPat = (pat: AccessToken) => {
+      setPersonalAccessTokens((prev) => mergeAccessTokens([...prev, pat]));
+    };
+    newPatEventEmitter.on("pat", handleNewPat);
+
+    return () => {
+      newPatEventEmitter.off("pat", handleNewPat);
+    };
   }, []);
 
   const handleDeletePat = async (pat: PersonalAccessTokenDTO) => {
@@ -90,7 +108,7 @@ export default function usePersonalAccessToken(
   }): Promise<SeeOncePatWithPrivKey | SeeOncePatWithBearerToken> {
     const pat = await createPat(data, baseUrl);
 
-    setPersonalAccessTokens((prev) => [...prev, pat]);
+    setPersonalAccessTokens((prev) => mergeAccessTokens([...prev, pat]));
     sessionStorage.setItem("pat", JSON.stringify(pat));
     newPatEventEmitter.emit("pat", pat);
     return pat;


### PR DESCRIPTION
## Summary

- merge personal access token state by stable token ID across API data, session storage, and cross-hook events
- preserve separately created token types that do not expose a fingerprint
- unsubscribe token event listeners when hook consumers unmount
- add lifecycle regression coverage for navigation remounts and distinct newly created tokens

Fixes l3montree-dev/devguard#2803.

## Validation

- `npm test -- --runInBand` (8 suites, 34 tests)
- `npx tsc --noEmit --pretty false`
- `npx prettier --check src/hooks/usePersonalAccessToken.ts src/hooks/usePersonalAccessToken.test.tsx`
- `git diff --check`

The npm, Jest, TypeScript, and formatting checks were run with Node 26.5.0 and npm 11.17.0, matching the repository's declared engine range.
