### PR TITLE
feat: add copy button to purl tooltip

### DIFF
--- a/src/components/common/Purl.tsx
+++ b/src/components/common/Purl.tsx
@@ -4,12 +4,14 @@ import {
   extractVersion,
   formatPurlQualifiers,
 } from "@/utils/common";
-import type { FunctionComponent } from "react";
+import { useState, type FunctionComponent, type MouseEvent } from "react";
+import { CheckIcon, CopyIcon } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { toast } from "@/lib/toast";
 import EcosystemImage from "./EcosystemImage";
 
 interface PurlProps {
@@ -31,9 +33,20 @@ const Purl: FunctionComponent<PurlProps> = ({
   showQualifiers = true,
   className,
 }) => {
+  const [copied, setCopied] = useState(false);
   const qualifiers = showQualifiers ? extractPurlQualifiers(purl) : "";
   const secondaryClassName =
     variant === "compact" ? "font-medium" : "text-xs text-muted-foreground";
+
+  const handleCopy = (e: MouseEvent) => {
+    //to prevent opening package behind the copy button
+    e.preventDefault();
+    e.stopPropagation();
+    navigator.clipboard.writeText(purl);
+    setCopied(true);
+    toast.success("Copied to clipboard");
+    setTimeout(() => setCopied(false), 1500);
+  };
 
   return (
     <Tooltip>
@@ -65,8 +78,22 @@ const Purl: FunctionComponent<PurlProps> = ({
           )}
         </span>
       </TooltipTrigger>
-      <TooltipContent className="max-w-sm break-all font-mono">
-        {purl}
+      <TooltipContent className="max-w-sm font-mono">
+        <span className="flex items-start gap-1.5">
+          <span className="break-all">{purl}</span>
+          <button
+            onClick={handleCopy}
+            type="button"
+            aria-label="copy purl to clipboard"
+            className="-my-0.25 -mr-1 rounded-md shrink-0 p-1 transition-all hover:bg-foreground/10"
+          >
+            {copied ? (
+              <CheckIcon className="h-3.5 w-3.5" />
+            ) : (
+              <CopyIcon className="h-3.5 w-3.5" />
+            )}
+          </button>
+        </span>
       </TooltipContent>
     </Tooltip>
   );


### PR DESCRIPTION

<img width="222" height="149" alt="purl-copy-button" src="https://github.com/user-attachments/assets/a1a947de-cd47-4573-ae66-fa2949729d66" />


Added copy button to the purl component.
Triggers a toast on successful copy and temporarily makes the button a checkmark for visual feedback.

Resolves l3montree-dev/devguard#2795