### PR TITLE
fix: link EUVD aliases to ENISA

### DIFF
--- a/src/components/AffectedComponent.tsx
+++ b/src/components/AffectedComponent.tsx
@@ -5,7 +5,11 @@ import type {
   DetailedDependencyVulnDTO,
   PURLInspectResponse,
 } from "@/types/api/api";
-import { beautifyPurl, extractVersion } from "@/utils/common";
+import {
+  beautifyPurl,
+  extractVersion,
+  getVulnerabilitySourceUrl,
+} from "@/utils/common";
 import { useMemo, type FunctionComponent } from "react";
 import EcosystemImage from "./common/EcosystemImage";
 import { Badge } from "./ui/badge";
@@ -127,7 +131,7 @@ const AffectedComponentDetails: FunctionComponent<{
                       .map((cve, index) => (
                         <Link
                           key={`${cve.cveID}-${index}`}
-                          href={`https://osv.dev/vulnerability/${cve.cve}`}
+                          href={getVulnerabilitySourceUrl(cve.cve)}
                           target="_blank"
                           className="!text-xs"
                         >
@@ -148,7 +152,7 @@ const AffectedComponentDetails: FunctionComponent<{
                               className="flex flex-row gap-2"
                             >
                               <Link
-                                href={`https://osv.dev/vulnerability/${rel.targetCve}`}
+                                href={getVulnerabilitySourceUrl(rel.targetCve)}
                                 target="_blank"
                                 className="!text-xs"
                               >

--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -2,6 +2,7 @@ import {
   beautifyPurl,
   extractPurlQualifiers,
   formatPurlQualifiers,
+  getVulnerabilitySourceUrl,
 } from "./common";
 
 describe("beautifyPurl", () => {
@@ -38,5 +39,19 @@ describe("formatPurlQualifiers", () => {
     expect(formatted.length).toBeLessThanOrEqual(48);
     expect(formatted).toContain("...");
     expect(formatted.startsWith("download_url=")).toBe(true);
+  });
+});
+
+describe("getVulnerabilitySourceUrl", () => {
+  it("links EUVD identifiers to the ENISA vulnerability record", () => {
+    expect(getVulnerabilitySourceUrl("EUVD-2026-61112")).toBe(
+      "https://euvd.enisa.europa.eu/enisa/EUVD-2026-61112",
+    );
+  });
+
+  it("keeps other vulnerability identifiers linked to OSV", () => {
+    expect(getVulnerabilitySourceUrl("CVE-2026-12345")).toBe(
+      "https://osv.dev/vulnerability/CVE-2026-12345",
+    );
   });
 });

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -163,6 +163,11 @@ export const isNumber = (v: any): v is number => {
   return typeof v === "number" && v === v;
 };
 
+export const getVulnerabilitySourceUrl = (vulnerabilityId: string): string =>
+  vulnerabilityId.startsWith("EUVD-")
+    ? `https://euvd.enisa.europa.eu/enisa/${vulnerabilityId}`
+    : `https://osv.dev/vulnerability/${vulnerabilityId}`;
+
 export const beautifyPurl = (purl: string): string => {
   if (purl === "ROOT") {
     return "Your application";


### PR DESCRIPTION
## Summary

- route `EUVD-*` identifiers to their ENISA EUVD records
- keep CVE and other vulnerability identifiers linked to OSV
- use the helper for both matched CVEs and relationship aliases
- add URL-routing regression tests

## Why

Affected-component links were built with an unconditional OSV URL, even when the displayed identifier belonged to EUVD.

## Validation

- full Jest suite: 7 suites, 33 tests passed
- targeted ESLint on all modified files
- Prettier check on all modified files

The repository-wide lint command still reports 90 unrelated pre-existing findings; all touched files pass.

Fixes l3montree-dev/devguard#2882