### PR TITLE
fix: adjusted org overview for edge cases

### DIFF
--- a/src/components/RiskHistoryDistributionDiagram.tsx
+++ b/src/components/RiskHistoryDistributionDiagram.tsx
@@ -40,6 +40,12 @@ export function RiskHistoryDistributionDiagram({
         <CardTitle className="text-base">
           {mode === "risk" ? "Risk" : "CVSS"} Distribution Trend
         </CardTitle>
+        <CardDescription>
+          How the number of vulnerabilities per{" "}
+          {mode === "risk" ? "risk" : "CVSS"} severity develops over time.
+          {data.length < 3 &&
+            " At least 3 days of data are needed for a more meaningful trend."}
+        </CardDescription>
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -106,12 +112,14 @@ export function RiskHistoryDistributionDiagram({
                       day: "numeric",
                     })
                   }
-                  content={
+                  content={({ content, ...props }) => (
                     <ChartTooltipContent
+                      {...props}
+                      payload={[...(props.payload ?? [])].reverse()}
                       indicator="dot"
                       className="bg-background"
                     />
-                  }
+                  )}
                 />
                 <defs>
                   {["critical", "high", "medium", "low"].map((level, i) => {
@@ -140,10 +148,10 @@ export function RiskHistoryDistributionDiagram({
                   })}
                 </defs>
                 {[
-                  { dataKey: "cvePurlCritical", severity: "critical" },
-                  { dataKey: "cvePurlHigh", severity: "high" },
-                  { dataKey: "cvePurlMedium", severity: "medium" },
                   { dataKey: "cvePurlLow", severity: "low" },
+                  { dataKey: "cvePurlMedium", severity: "medium" },
+                  { dataKey: "cvePurlHigh", severity: "high" },
+                  { dataKey: "cvePurlCritical", severity: "critical" },
                 ].map(({ dataKey, severity }) => (
                   <Area
                     key={dataKey}

--- a/src/components/organization/AverageStatsSection.tsx
+++ b/src/components/organization/AverageStatsSection.tsx
@@ -69,6 +69,14 @@ export default function AverageStatsSection({
     },
   ];
 
+  const hasData =
+    isStatisticsLoading ||
+    Object.values(orgStatistics?.vulnEventAverage ?? {}).some(
+      (value) => Number(value) > 0,
+    );
+
+  if (!hasData) return null;
+
   return (
     <Section
       forceVertical

--- a/src/components/organization/MostVulnerableList.tsx
+++ b/src/components/organization/MostVulnerableList.tsx
@@ -65,7 +65,7 @@ const MostVulnerableList: FunctionComponent<Props> = ({
   }
 
   return (
-    <Card>
+    <Card className="flex flex-1 flex-col">
       <CardHeader>
         <CardTitle className="text-base">{title}</CardTitle>
         <CardDescription className="text-sm">


### PR DESCRIPTION
<img width="849" height="322" alt="Bildschirmfoto 2026-08-25 um 14 09 13" src="https://github.com/user-attachments/assets/e4458a9d-1a85-424c-9d15-92fc4131f781" />
<img width="835" height="312" alt="Bildschirmfoto 2026-08-25 um 14 09 20" src="https://github.com/user-attachments/assets/51edcd65-f801-4a6e-b0e1-d24a8c4f1357" />

And the whole AverageStatsSection is not displayed when every value of vulnEventAverage is 0
