### PR TITLE
fix: risk history distribution diagram

### DIFF
--- a/src/components/RiskHistoryDistributionDiagram.tsx
+++ b/src/components/RiskHistoryDistributionDiagram.tsx
@@ -17,14 +17,7 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { RiskHistoryPoint } from "@/types/view/riskHistory";
-import {
-  Area,
-  AreaChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import { severityToColor } from "./common/Severity";
 import { Skeleton } from "./ui/skeleton";
 
@@ -54,123 +47,122 @@ export function RiskHistoryDistributionDiagram({
         {isLoading ? (
           <Skeleton className="w-full h-[300px]" />
         ) : (
-          <ResponsiveContainer width="100%" height={300}>
-            <ChartContainer
-              config={{
-                cvePurlCritical: {
-                  label: "Critical",
-                  color: severityToColor("CRITICAL"),
-                },
-                cvePurlCriticalCvss: {
-                  label: "Critical",
-                  color: severityToColor("CRITICAL"),
-                },
-                cvePurlHigh: {
-                  label: "High",
-                  color: severityToColor("HIGH"),
-                },
-                cvePurlHighCvss: {
-                  label: "High",
-                  color: severityToColor("HIGH"),
-                },
-                cvePurlMedium: {
-                  label: "Medium",
-                  color: severityToColor("MEDIUM"),
-                },
-                cvePurlMediumCvss: {
-                  label: "Medium",
-                  color: severityToColor("MEDIUM"),
-                },
-                cvePurlLow: {
-                  label: "Low",
-                  color: severityToColor("LOW"),
-                },
-                cvePurlLowCvss: {
-                  label: "Low",
-                  color: severityToColor("LOW"),
-                },
-              }}
-            >
-              <AreaChart accessibilityLayer data={data}>
-                <ChartLegend content={<ChartLegendContent />} />
-                <CartesianGrid vertical={false} />
-                <XAxis
-                  dataKey="day"
-                  tickLine={false}
-                  axisLine={false}
-                  tickMargin={8}
-                  tickFormatter={(value) => {
-                    return new Date(value).toLocaleDateString("de-DE", {
-                      month: "short",
-                      day: "numeric",
-                    });
-                  }}
-                />
-                <YAxis />
-                <ChartTooltip
-                  cursor={false}
-                  labelFormatter={(value) =>
-                    new Date(String(value)).toLocaleDateString("de-DE", {
-                      month: "short",
-                      day: "numeric",
-                    })
-                  }
-                  content={({ content, ...props }) => (
-                    <ChartTooltipContent
-                      {...props}
-                      payload={[...(props.payload ?? [])].reverse()}
-                      indicator="dot"
-                      className="bg-background"
-                    />
-                  )}
-                />
-                <defs>
-                  {["critical", "high", "medium", "low"].map((level) => {
-                    const sev = level.toUpperCase();
-                    return (
-                      <linearGradient
-                        key={level}
-                        id={`fill-${level}`}
-                        x1="0"
-                        y1="0"
-                        x2="0"
-                        y2="1"
-                      >
-                        <stop
-                          offset="5%"
-                          stopColor={severityToColor(sev)}
-                          stopOpacity={0.2}
-                        />
-                        <stop
-                          offset="95%"
-                          stopColor={severityToColor(sev)}
-                          stopOpacity={0.2}
-                        />
-                      </linearGradient>
-                    );
-                  })}
-                </defs>
-                {[
-                  { dataKey: "cvePurlLow", severity: "low" },
-                  { dataKey: "cvePurlMedium", severity: "medium" },
-                  { dataKey: "cvePurlHigh", severity: "high" },
-                  { dataKey: "cvePurlCritical", severity: "critical" },
-                ].map(({ dataKey, severity }) => (
-                  <Area
-                    key={dataKey}
-                    dataKey={mode === "risk" ? dataKey : dataKey + "Cvss"}
-                    type="monotone"
-                    stackId="1"
-                    stroke={severityToColor(severity.toUpperCase())}
-                    strokeWidth={2}
-                    fill={`url(#fill-${severity})`}
-                    fillOpacity={0.8}
-                    dot={false}
+          <ChartContainer
+            className="h-[300px] w-full"
+            config={{
+              cvePurlCritical: {
+                label: "Critical",
+                color: severityToColor("CRITICAL"),
+              },
+              cvePurlCriticalCvss: {
+                label: "Critical",
+                color: severityToColor("CRITICAL"),
+              },
+              cvePurlHigh: {
+                label: "High",
+                color: severityToColor("HIGH"),
+              },
+              cvePurlHighCvss: {
+                label: "High",
+                color: severityToColor("HIGH"),
+              },
+              cvePurlMedium: {
+                label: "Medium",
+                color: severityToColor("MEDIUM"),
+              },
+              cvePurlMediumCvss: {
+                label: "Medium",
+                color: severityToColor("MEDIUM"),
+              },
+              cvePurlLow: {
+                label: "Low",
+                color: severityToColor("LOW"),
+              },
+              cvePurlLowCvss: {
+                label: "Low",
+                color: severityToColor("LOW"),
+              },
+            }}
+          >
+            <AreaChart accessibilityLayer data={data}>
+              <ChartLegend content={<ChartLegendContent />} />
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="day"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                tickFormatter={(value) => {
+                  return new Date(value).toLocaleDateString("de-DE", {
+                    month: "short",
+                    day: "numeric",
+                  });
+                }}
+              />
+              <YAxis />
+              <ChartTooltip
+                cursor={false}
+                labelFormatter={(value) =>
+                  new Date(String(value)).toLocaleDateString("de-DE", {
+                    month: "short",
+                    day: "numeric",
+                  })
+                }
+                content={({ content, ...props }) => (
+                  <ChartTooltipContent
+                    {...props}
+                    payload={[...(props.payload ?? [])].reverse()}
+                    indicator="dot"
+                    className="bg-background"
                   />
-                ))}
-              </AreaChart>
-            </ChartContainer>
-          </ResponsiveContainer>
+                )}
+              />
+              <defs>
+                {["critical", "high", "medium", "low"].map((level) => {
+                  const sev = level.toUpperCase();
+                  return (
+                    <linearGradient
+                      key={level}
+                      id={`fill-${level}`}
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="1"
+                    >
+                      <stop
+                        offset="5%"
+                        stopColor={severityToColor(sev)}
+                        stopOpacity={0.2}
+                      />
+                      <stop
+                        offset="95%"
+                        stopColor={severityToColor(sev)}
+                        stopOpacity={0.2}
+                      />
+                    </linearGradient>
+                  );
+                })}
+              </defs>
+              {[
+                { dataKey: "cvePurlLow", severity: "low" },
+                { dataKey: "cvePurlMedium", severity: "medium" },
+                { dataKey: "cvePurlHigh", severity: "high" },
+                { dataKey: "cvePurlCritical", severity: "critical" },
+              ].map(({ dataKey, severity }) => (
+                <Area
+                  key={dataKey}
+                  dataKey={mode === "risk" ? dataKey : dataKey + "Cvss"}
+                  type="monotone"
+                  stackId="1"
+                  stroke={severityToColor(severity.toUpperCase())}
+                  strokeWidth={2}
+                  fill={`url(#fill-${severity})`}
+                  fillOpacity={0.8}
+                  dot={false}
+                />
+              ))}
+            </AreaChart>
+          </ChartContainer>
         )}
       </CardContent>
       <CardFooter className="flex-col items-start gap-2 text-sm">


### PR DESCRIPTION
It was quite difficult to find the root cause of the problem. After a lot of tries and looking into old code I came with help of AI to this solution:

I remove nested ResponsiveContainer in RiskHistoryDistributionDiagram

RiskHistoryDistributionDiagram wrapped ChartContainer in its own
<ResponsiveContainer>, even though ChartContainer already renders one
internally. This double nesting was harmless under Recharts 2, but the
API-client migration (#915) bumped Recharts to v3, which measures
ResponsiveContainer more strictly via ResizeObserver. With two nested
instances, the inner one now resolves to a 0x0 box on its first layout
pass while it's waiting on a parent that the outer instance is still
measuring, so the chart renders empty even though the API returns valid
orgRiskHistory data.

No other chart in the codebase nests ResponsiveContainer inside
ChartContainer, so this component was the only one affected. 

<img width="908" height="484" alt="Bildschirmfoto 2026-09-03 um 08 47 36" src="https://github.com/user-attachments/assets/ca0552cf-8cd6-498f-a8f4-be9058e7b661" />
