### PR TITLE
fix: path to component is now unlocked even vex rule is there

### DIFF
--- a/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
+++ b/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/refs/[assetVersionSlug]/dependency-risks/[vulnId]/page.tsx
@@ -461,7 +461,7 @@ const Index: FunctionComponent = () => {
                   <Skeleton className="w-full h-20" />
                 )}
               </div>
-              <div data-tour="path" className={lockedOverlay}>
+              <div data-tour="path">
                 {!graphLoading && (
                   <div className="mt-6">
                     {vuln && vuln.vulnerabilityPath.length > 0 && (


### PR DESCRIPTION
<img width="967" height="770" alt="Bildschirmfoto 2026-09-03 um 09 23 20" src="https://github.com/user-attachments/assets/6e791f90-e9e4-49dd-8263-6f27ed5e42a4" />
