### PR TITLE
fix: added onboarding prop so back buttons are optional

### DIFF
--- a/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/page.tsx
+++ b/src/app/(loading-group)/[organizationSlug]/projects/[projectSlug]/assets/[assetSlug]/page.tsx
@@ -369,6 +369,7 @@ const Index: FunctionComponent = () => {
         devguardCIComponentBase={config.devguardCIComponentBase}
         devguardWebLatestScannerImage={latestScannerImage}
         initialSlide={riskScanningInitialSlide}
+        onboarding
       />
       <WebhookSetupTicketIntegrationDialog
         open={webhookIsOpen}

--- a/src/components/RiskScannerDialog.tsx
+++ b/src/components/RiskScannerDialog.tsx
@@ -61,6 +61,7 @@ interface RiskScannerDialogProps {
   devguardWebLatestScannerImage: string;
   initialSlide?: number;
   defaultCliTab?: "sca" | "sast";
+  onboarding?: boolean;
 }
 
 const RiskScannerDialog: FunctionComponent<RiskScannerDialogProps> = ({
@@ -74,6 +75,7 @@ const RiskScannerDialog: FunctionComponent<RiskScannerDialogProps> = ({
   devguardWebLatestScannerImage,
   initialSlide,
   defaultCliTab,
+  onboarding,
 }) => {
   const [api, setApi] = React.useState<{
     reInit: () => void;
@@ -560,6 +562,7 @@ const RiskScannerDialog: FunctionComponent<RiskScannerDialogProps> = ({
               api={api}
               tokenSlideIndex={asset.repositoryProvider === "github" ? 8 : 9}
               prevIndex={prevIndex}
+              onboarding={onboarding}
             />
             <GithubTokenSlide
               pat={accessToken.accessToken?.privKey}
@@ -608,6 +611,7 @@ const RiskScannerDialog: FunctionComponent<RiskScannerDialogProps> = ({
               cliSlideIndex={12}
               fileUploadSlideIndex={13}
               prevIndex={prevIndex}
+              onboarding={onboarding}
             />
             <AutomatedIntegrationSlide
               apiUrl={apiUrl}
@@ -648,6 +652,7 @@ const RiskScannerDialog: FunctionComponent<RiskScannerDialogProps> = ({
               api={api}
               prevIndex={prevIndex}
               onInformationSourceSetup={handleInformationSourceSetup}
+              onboarding={onboarding}
             />
             <DevGuardCliSlide
               onClose={() => onOpenChange(false)}
@@ -655,6 +660,7 @@ const RiskScannerDialog: FunctionComponent<RiskScannerDialogProps> = ({
               prevIndex={prevIndex}
               scannerImage={devguardWebLatestScannerImage}
               defaultTab={defaultCliTab}
+              onboarding={onboarding}
             />
           </CarouselContent>
         </Carousel>

--- a/src/components/guides/risk-scanner-carousel-slides/DevGuardCliSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/DevGuardCliSlide.tsx
@@ -38,6 +38,7 @@ interface DevGuardCliSlideProps {
   prevIndex: number;
   scannerImage: string;
   defaultTab?: "sca" | "sast";
+  onboarding?: boolean;
 }
 
 export const DevGuardCliSlide: FunctionComponent<DevGuardCliSlideProps> = ({
@@ -46,6 +47,7 @@ export const DevGuardCliSlide: FunctionComponent<DevGuardCliSlideProps> = ({
   onClose,
   scannerImage,
   defaultTab = "sca",
+  onboarding,
 }) => {
   const accessToken = useAccessToken();
   const org = useActiveOrg();
@@ -141,13 +143,15 @@ ${generateDockerSnippet(scannerImage, "sast", org.slug, project.slug, asset.slug
         </Tabs>
 
         <div className="mt-0 flex flex-wrap flex-row gap-2 justify-end">
-          <Button
-            variant={"secondary"}
-            id="devguard-cli-scan-back-to-selection"
-            onClick={() => api?.scrollTo(prevIndex)}
-          >
-            Back
-          </Button>
+          {!onboarding && (
+            <Button
+              variant={"secondary"}
+              id="devguard-cli-scan-back-to-selection"
+              onClick={() => api?.scrollTo(prevIndex)}
+            >
+              Back
+            </Button>
+          )}
           <Button id="install-devguard-cli-finish" onClick={onClose}>
             Finish
           </Button>

--- a/src/components/guides/risk-scanner-carousel-slides/IntegrationMethodSelectionSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/IntegrationMethodSelectionSlide.tsx
@@ -34,11 +34,19 @@ interface IntegrationMethodSelectionSlideProps {
   cliSlideIndex: number;
   fileUploadSlideIndex: number;
   prevIndex: number;
+  onboarding?: boolean;
 }
 
 const IntegrationMethodSelectionSlide: FunctionComponent<
   IntegrationMethodSelectionSlideProps
-> = ({ api, setVariant, cliSlideIndex, fileUploadSlideIndex, prevIndex }) => {
+> = ({
+  api,
+  setVariant,
+  cliSlideIndex,
+  fileUploadSlideIndex,
+  prevIndex,
+  onboarding,
+}) => {
   return (
     <CarouselItem>
       <div className="">
@@ -89,15 +97,17 @@ const IntegrationMethodSelectionSlide: FunctionComponent<
               </CardDescription>
             </CardHeader>
           </Card>
-          <div className="mt-4 flex flex-row gap-2 justify-end">
-            <Button
-              variant={"secondary"}
-              id="integration-method-back-to-selection"
-              onClick={() => api?.scrollTo(prevIndex)}
-            >
-              Back
-            </Button>
-          </div>
+          {!onboarding && (
+            <div className="mt-4 flex flex-row gap-2 justify-end">
+              <Button
+                variant={"secondary"}
+                id="integration-method-back-to-selection"
+                onClick={() => api?.scrollTo(prevIndex)}
+              >
+                Back
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </CarouselItem>

--- a/src/components/guides/risk-scanner-carousel-slides/ScannerOptionsSelectionSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/ScannerOptionsSelectionSlide.tsx
@@ -27,11 +27,12 @@ interface ScannerOptionsSelectionSlideProps {
   };
   tokenSlideIndex: number;
   prevIndex: number;
+  onboarding?: boolean;
 }
 
 const ScannerOptionsSelectionSlide: FunctionComponent<
   ScannerOptionsSelectionSlideProps
-> = ({ config, setConfig, api, tokenSlideIndex, prevIndex }) => {
+> = ({ config, setConfig, api, tokenSlideIndex, prevIndex, onboarding }) => {
   return (
     <CarouselItem>
       <DialogHeader>
@@ -510,13 +511,15 @@ const ScannerOptionsSelectionSlide: FunctionComponent<
       </div>
 
       <div className="mt-4 flex flex-row gap-2 justify-end">
-        <Button
-          variant={"secondary"}
-          id="scanner-options-back-to-selection"
-          onClick={() => api?.scrollTo(prevIndex)}
-        >
-          Back
-        </Button>
+        {!onboarding && (
+          <Button
+            variant={"secondary"}
+            id="scanner-options-back-to-selection"
+            onClick={() => api?.scrollTo(prevIndex)}
+          >
+            Back
+          </Button>
+        )}
         <Button
           disabled={Object.values(config).every((v) => v === false)}
           id="scanner-options-selection-continue"

--- a/src/components/guides/risk-scanner-carousel-slides/SetupInformationSourceSlide.tsx
+++ b/src/components/guides/risk-scanner-carousel-slides/SetupInformationSourceSlide.tsx
@@ -25,11 +25,12 @@ interface SetupInformationSourceSlideProps {
     isDefault: boolean;
     informationSources: Array<{ url: string; purl?: string }>;
   }) => Promise<void>;
+  onboarding?: boolean;
 }
 
 export const SetupInformationSourceSlide: FunctionComponent<
   SetupInformationSourceSlideProps
-> = ({ api, onInformationSourceSetup, prevIndex }) => {
+> = ({ api, onInformationSourceSetup, prevIndex, onboarding }) => {
   const form = useForm<ArtifactRequest>({
     defaultValues: {
       artifactName: "",
@@ -88,14 +89,16 @@ export const SetupInformationSourceSlide: FunctionComponent<
         >
           <ArtifactForm form={form} isEditMode={false} />
           <div className="mt-4 flex flex-wrap flex-row gap-2 justify-end">
-            <Button
-              variant={"secondary"}
-              type="button"
-              id="setup-information-sources-back-to-selection"
-              onClick={() => api?.scrollTo(prevIndex)}
-            >
-              Back
-            </Button>
+            {!onboarding && (
+              <Button
+                variant={"secondary"}
+                type="button"
+                id="setup-information-sources-back-to-selection"
+                onClick={() => api?.scrollTo(prevIndex)}
+              >
+                Back
+              </Button>
+            )}
             <Button
               isSubmitting={form.formState.isSubmitting}
               id="setup-information-sources-create"


### PR DESCRIPTION
On the onboarding screen of an asset the back buttons are now hidden:
<img width="1632" height="755" alt="Bildschirmfoto 2026-09-03 um 10 18 24" src="https://github.com/user-attachments/assets/15574362-8f2c-4098-92bf-fa54251b3703" />

At the dependency risk table when pressed "identify risk" the back buttons are still there because they make sense to navigate back to the parent slide:
<img width="1645" height="785" alt="Bildschirmfoto 2026-09-03 um 10 18 16" src="https://github.com/user-attachments/assets/3f12b74e-5d28-4cb2-9901-c95afdf55029" />

