### PR TITLE
fix: removed double tooltip content of dep table

### DIFF
--- a/src/components/risk-handling/RiskHandlingRow.tsx
+++ b/src/components/risk-handling/RiskHandlingRow.tsx
@@ -199,20 +199,6 @@ const VulnWithCveTableRow = ({
                   </div>
                 </Link>
               </TooltipTrigger>
-              <TooltipContent>
-                <div className="flex flex-wrap flex-row items-start gap-2 break-all max-w-md">
-                  {vuln.vulnerabilityPath.map((el, i) => (
-                    <span className="flex flex-row items-center gap-1" key={i}>
-                      <Purl
-                        purl={el}
-                        showVersion={false}
-                        showQualifiers={false}
-                      />
-                      {i < vuln.vulnerabilityPath.length - 1 ? " → " : null}
-                    </span>
-                  ))}
-                </div>
-              </TooltipContent>
             </Tooltip>
           </div>
         </div>


### PR DESCRIPTION
<img width="368" height="117" alt="Bildschirmfoto 2026-09-04 um 16 32 51" src="https://github.com/user-attachments/assets/c39e045b-f16e-4fad-9189-a25597fb3d00" />
